### PR TITLE
[Spec 1][Phase 7] feat: Markdown + Word (.docx) emitters

### DIFF
--- a/src/arabic_pdf_transcribe/emit/__init__.py
+++ b/src/arabic_pdf_transcribe/emit/__init__.py
@@ -1,0 +1,38 @@
+"""Phase-7 emitters: Markdown and Word (.docx).
+
+Converts an ordered, role-classified :class:`Region` stream into a
+human-readable artefact while preserving Unicode bidi correctness and
+Arabic presentation-form fidelity.
+
+Both emitters are pure functions of their input region stream (the
+docx emitter takes an output path so it can write the file directly,
+but it does not read environment state). Snapshots are stable across
+runs: no timestamps, no environment-dependent data, deterministic
+ordering.
+
+Importing this package does *not* pull in :mod:`docx`; that import
+is deferred to :func:`emit_docx`.
+"""
+
+from __future__ import annotations
+
+from arabic_pdf_transcribe.emit._normalise import (
+    NormalisationForm,
+    normalise_text,
+)
+from arabic_pdf_transcribe.emit.markdown import emit_markdown
+
+
+def emit_docx(*args: object, **kwargs: object) -> None:
+    """Lazy proxy: defers ``python-docx`` import until first call."""
+    from arabic_pdf_transcribe.emit.docx import emit_docx as _emit_docx
+
+    return _emit_docx(*args, **kwargs)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "NormalisationForm",
+    "emit_docx",
+    "emit_markdown",
+    "normalise_text",
+]

--- a/src/arabic_pdf_transcribe/emit/_bidi.py
+++ b/src/arabic_pdf_transcribe/emit/_bidi.py
@@ -1,0 +1,85 @@
+"""Bidi helpers for emitter output.
+
+Spec rule: when an Arabic-dominant paragraph contains LTR runs (Latin
+words, Western digits in non-numeric positions, URLs), the output
+must keep the visual ordering stable across renderers. Many Markdown
+renderers and Word do the right thing without any hint, but a
+stray strong-LTR character at the start of a logical-Arabic paragraph
+can cause whole-line direction flips on naïve renderers.
+
+The conservative fix: prefix the paragraph with U+200F (RIGHT-TO-LEFT
+MARK, RLM) when the dominant script is Arabic *and* the text
+contains at least one LTR character. RLM is invisible, has no width,
+and forces a strong-RTL context.
+
+We do **not** insert RLM in every paragraph — empty paragraphs and
+pure-Arabic / pure-LTR paragraphs need none. The decision is purely
+deterministic so snapshot tests stay stable.
+
+References:
+- Unicode TR9 (Bidirectional Algorithm)
+- :func:`unicodedata.bidirectional` returns the bidi class:
+  ``"AL"`` (Arabic letter), ``"R"`` (Hebrew etc), ``"L"`` (LTR),
+  ``"EN"`` / ``"AN"`` (digits — weak, not classified as LTR/RTL).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+RLM = "‏"
+"""RIGHT-TO-LEFT MARK — invisible strong-RTL character."""
+
+
+def _classify_char(ch: str) -> str:
+    """Return ``"R"``, ``"L"``, or ``""`` (neutral / weak)."""
+    cls = unicodedata.bidirectional(ch)
+    if cls in ("AL", "R"):
+        return "R"
+    if cls == "L":
+        return "L"
+    return ""
+
+
+def is_arabic_dominant(text: str) -> bool:
+    """Return ``True`` when more strong-RTL than strong-LTR characters."""
+    rtl = ltr = 0
+    for ch in text:
+        kind = _classify_char(ch)
+        if kind == "R":
+            rtl += 1
+        elif kind == "L":
+            ltr += 1
+    return rtl > 0 and rtl > ltr
+
+
+def has_ltr_run(text: str) -> bool:
+    """Return ``True`` when ``text`` contains a strong-LTR character."""
+    return any(_classify_char(ch) == "L" for ch in text)
+
+
+def add_rlm_if_needed(text: str) -> str:
+    """Prefix ``text`` with U+200F when Arabic-dominant + contains LTR.
+
+    Idempotent: re-applying does not double-prefix because a leading
+    RLM is itself strong-RTL, so the dominance check still triggers,
+    but the function detects an existing leading RLM and returns the
+    input unchanged.
+    """
+    if not text:
+        return text
+    if text.startswith(RLM):
+        return text
+    if not is_arabic_dominant(text):
+        return text
+    if not has_ltr_run(text):
+        return text
+    return RLM + text
+
+
+__all__ = [
+    "RLM",
+    "add_rlm_if_needed",
+    "has_ltr_run",
+    "is_arabic_dominant",
+]

--- a/src/arabic_pdf_transcribe/emit/_md_escape.py
+++ b/src/arabic_pdf_transcribe/emit/_md_escape.py
@@ -1,0 +1,96 @@
+"""Markdown escaping helpers.
+
+Region text may contain characters that Markdown interprets
+structurally:
+
+* Leading ``# `` → unintended heading.
+* Leading ``- ``, ``* ``, ``+ `` → unintended bullet.
+* Leading digits + ``.`` or ``)`` → unintended ordered list.
+* Leading ``> `` → unintended blockquote.
+* Pipe ``|`` inside a table cell → unintended column break.
+* Backslash, backtick, asterisk, underscore, square brackets — inline
+  emphasis / link syntax.
+
+The emitter calls :func:`escape_paragraph` for plain prose and
+:func:`escape_table_cell` for table cell text. Both are conservative
+— they escape what would actually be parsed structurally, not every
+ambiguous character. Over-escaping makes the output noisy and breaks
+round-trip with downstream Markdown renderers.
+
+Escapes are **deterministic** so snapshot tests are stable.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Inline characters that always need escaping when they appear in a
+# paragraph or cell. The list mirrors CommonMark's ASCII punctuation
+# rule but is restricted to characters that are *actively* used as
+# Markdown syntax — escaping every ASCII punctuation mark would be
+# noisy and harm readability.
+_INLINE_ESCAPE_RE = re.compile(r"([\\`*_\[\]<>])")
+
+# A leading-line pattern for block constructs we need to neutralise.
+# Order matters: longer matches first.
+_LEADING_BLOCK_RE = re.compile(
+    r"^(?P<prefix>"
+    r"#{1,6}\s"  # ATX heading
+    r"|>\s?"  # blockquote
+    r"|[-*+]\s"  # bullet list
+    r"|\d+[.)]\s"  # ordered list
+    r")"
+)
+
+
+def escape_inline(text: str) -> str:
+    """Escape inline Markdown syntax characters.
+
+    Applied to all paragraph / heading text. Keeps Arabic letters
+    untouched (they are not in the escape set).
+    """
+    return _INLINE_ESCAPE_RE.sub(r"\\\1", text)
+
+
+def escape_paragraph(text: str) -> str:
+    """Escape a full paragraph, including any leading block construct.
+
+    Two-pass:
+
+    1. Escape inline syntax characters in the body.
+    2. If the (possibly escaped) line begins with a Markdown block
+       construct (``# ``, ``- ``, ``> ``, ``1. ``…), prefix the
+       construct's first character with a backslash so it is rendered
+       as literal text rather than a heading / list / quote.
+
+    Multi-line input: each line is processed independently for the
+    leading-block check so a paragraph containing an embedded line
+    that *looks* like a heading does not silently render as one.
+    """
+    out_lines: list[str] = []
+    for line in text.split("\n"):
+        escaped = escape_inline(line)
+        match = _LEADING_BLOCK_RE.match(escaped)
+        if match is not None:
+            escaped = "\\" + escaped
+        out_lines.append(escaped)
+    return "\n".join(out_lines)
+
+
+def escape_table_cell(text: str) -> str:
+    """Escape text for use inside a Markdown pipe-table cell.
+
+    Pipes (``|``) and newlines must be escaped because they would
+    otherwise terminate the cell or row. Inline syntax characters are
+    *also* escaped so that adversarial cell text (e.g. ``**bold**``)
+    renders as literal characters.
+    """
+    escaped = escape_inline(text)
+    escaped = escaped.replace("|", "\\|")
+    # Newlines inside cells: replace with HTML <br> so Markdown
+    # renderers preserve them. Plain ``\n`` would close the row.
+    escaped = escaped.replace("\n", "<br>")
+    return escaped
+
+
+__all__ = ["escape_inline", "escape_paragraph", "escape_table_cell"]

--- a/src/arabic_pdf_transcribe/emit/_normalise.py
+++ b/src/arabic_pdf_transcribe/emit/_normalise.py
@@ -1,0 +1,84 @@
+"""Unicode normalisation policy for the emitters.
+
+Architect carry-over (phase 3 PR-4 approval): phase 7 must explicitly
+decide between NFC and NFKC for Arabic presentation forms.
+
+## Decision: NFC default, NFKC opt-in
+
+Arabic text in PDF documents frequently arrives in **presentation
+forms** — codepoints in the ranges:
+
+* ``U+FB50..U+FDFF`` (Arabic Presentation Forms-A): ligatures and
+  isolated/initial/medial/final variants of base letters.
+* ``U+FE70..U+FEFF`` (Arabic Presentation Forms-B): contextual shaping
+  forms (isolated/initial/medial/final).
+
+These are **compatibility decompositions** of base letters. NFKC
+collapses them into their base forms; NFC does not.
+
+We default to **NFC** because:
+
+1. Many Arabic publishers intentionally emit presentation forms (e.g.
+   the Allah ligature ``U+FDF2`` ﷲ, lam-alef ligatures ``U+FEFB`` etc.)
+   for typographic reasons. NFKC would silently rewrite ﷲ → ا+ل+ل+ه,
+   losing the publisher's intent.
+2. Round-trip fidelity: a user copying transcribed text back into a
+   typesetting tool expects the same glyphs they saw in the source.
+3. NFC still applies canonical equivalence — combining marks are
+   ordered, decomposed-then-recomposed sequences are unified — so
+   text remains canonically stable across renderers without losing
+   compatibility-only information.
+
+NFKC is **opt-in** via :func:`normalise_text` ``form="NFKC"``. Users
+who want search-friendly text (where ﷲ matches a search for
+"الله") can request it explicitly. Phase 8's CLI may surface this
+as a flag in a future iteration; phase 9's corpus retune will
+revisit whether the default needs to change.
+
+## Empty / non-Arabic input
+
+The function applies the chosen form to all input regardless of
+script — this is correct behaviour: a Latin region in an Arabic
+document still needs canonical normalisation. NFKC's effects on
+Latin (full-width digits, ligatures, superscripts) are well-defined
+and non-controversial.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Literal
+
+NormalisationForm = Literal["NFC", "NFKC"]
+"""Allowed normalisation forms.
+
+Deliberately excludes NFD / NFKD: emitters require composed output
+(Word's :class:`docx` and most Markdown renderers prefer composed
+forms; combining-mark sequences in decomposed form render poorly in
+some Arabic-aware fonts).
+"""
+
+DEFAULT_FORM: NormalisationForm = "NFC"
+
+
+def normalise_text(text: str, *, form: NormalisationForm = DEFAULT_FORM) -> str:
+    """Normalise ``text`` to the requested Unicode form.
+
+    Parameters
+    ----------
+    text:
+        Input text (any script, any length).
+    form:
+        Either ``"NFC"`` (default — preserves Arabic presentation
+        forms) or ``"NFKC"`` (opt-in — collapses presentation forms
+        into base letters; lossy w.r.t. typography).
+
+    Returns
+    -------
+    str
+        Normalised text.
+    """
+    return unicodedata.normalize(form, text)
+
+
+__all__ = ["DEFAULT_FORM", "NormalisationForm", "normalise_text"]

--- a/src/arabic_pdf_transcribe/emit/docx.py
+++ b/src/arabic_pdf_transcribe/emit/docx.py
@@ -1,0 +1,276 @@
+"""Word (.docx) emitter.
+
+Converts an ordered, role-classified :class:`Region` stream into a
+``python-docx`` document. The mapping mirrors :mod:`emit.markdown`
+but uses Word's built-in styles instead of Markdown syntax.
+
+Mapping (see plan section "Phase 7"):
+
+* ``HEADING`` → built-in style ``Heading {level}``.
+* ``PARAGRAPH`` → ``Normal``.
+* ``LIST_ITEM`` → ``List Bullet`` or ``List Number``.
+* ``TABLE`` → real Word table from ``region.table_grid``; one
+  paragraph per cell.
+* ``FIGURE`` / ``CAPTION`` → placeholder paragraph
+  ``"Figure on page N"``; grouped caption text is appended.
+* ``HEADER_FOOTER`` → suppressed.
+* ``FAILURE_PLACEHOLDER`` → ``Quote`` style paragraph.
+* ``UNKNOWN`` → ``Normal``.
+
+The emitter is **deterministic**: no timestamps, no environment
+data, no document author / company metadata. Output is suitable for
+snapshot-style structural tests (open with ``python-docx``, walk
+paragraphs, assert styles).
+
+``python-docx`` is imported lazily — importing this module costs
+nothing until :func:`emit_docx` is first called.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from arabic_pdf_transcribe.emit._bidi import add_rlm_if_needed
+from arabic_pdf_transcribe.emit._normalise import (
+    DEFAULT_FORM,
+    NormalisationForm,
+    normalise_text,
+)
+from arabic_pdf_transcribe.regions import (
+    Region,
+    RegionRole,
+    TableGrid,
+)
+
+if TYPE_CHECKING:  # pragma: no cover — typing-only
+    from docx.document import Document as _DocxDocument
+
+
+def emit_docx(
+    regions: Iterable[Region],
+    output_path: Path | str,
+    *,
+    normalisation: NormalisationForm = DEFAULT_FORM,
+    apply_bidi: bool = True,
+) -> None:
+    """Render ``regions`` to a Word file at ``output_path``.
+
+    The output file is overwritten if it exists. The function does
+    not perform any network I/O.
+    """
+    from docx import Document
+
+    document = Document()
+    region_list = list(regions)
+    caption_group_ids = _collect_paired_caption_group_ids(region_list)
+    pending_caption_text: dict[str, str] = _collect_caption_texts(
+        region_list, normalisation=normalisation, paired=caption_group_ids
+    )
+
+    for region in region_list:
+        role = region.role
+        if role is RegionRole.HEADER_FOOTER:
+            continue
+        if role is RegionRole.CAPTION and region.group_id in caption_group_ids:
+            # Already rendered alongside the figure.
+            continue
+        if role is RegionRole.HEADING:
+            _add_heading(
+                document,
+                region,
+                normalisation=normalisation,
+                apply_bidi=apply_bidi,
+            )
+        elif role is RegionRole.LIST_ITEM:
+            _add_list_item(
+                document,
+                region,
+                normalisation=normalisation,
+                apply_bidi=apply_bidi,
+            )
+        elif role is RegionRole.TABLE:
+            _add_table(document, region, normalisation=normalisation)
+        elif role is RegionRole.FIGURE:
+            _add_figure(
+                document,
+                region,
+                pending_caption_text=pending_caption_text,
+            )
+        elif role is RegionRole.CAPTION:
+            _add_caption(
+                document,
+                region,
+                normalisation=normalisation,
+                apply_bidi=apply_bidi,
+            )
+        elif role is RegionRole.FAILURE_PLACEHOLDER:
+            _add_failure(document, region)
+        else:  # PARAGRAPH / UNKNOWN
+            _add_paragraph(
+                document,
+                region,
+                normalisation=normalisation,
+                apply_bidi=apply_bidi,
+            )
+
+    document.save(str(output_path))
+
+
+# ---------------------------------------------------------------------------
+# Pre-pass collectors
+# ---------------------------------------------------------------------------
+
+
+def _collect_paired_caption_group_ids(regions: Sequence[Region]) -> set[str]:
+    """Group ids where BOTH a caption and figure exist.
+
+    Captions are suppressed only when a paired figure consumes their
+    text; orphan grouped captions still render so the text is not
+    dropped.
+    """
+    figure_ids = {
+        region.group_id
+        for region in regions
+        if region.role is RegionRole.FIGURE and region.group_id is not None
+    }
+    caption_ids = {
+        region.group_id
+        for region in regions
+        if region.role is RegionRole.CAPTION and region.group_id is not None
+    }
+    return figure_ids & caption_ids
+
+
+def _collect_caption_texts(
+    regions: Sequence[Region],
+    *,
+    normalisation: NormalisationForm,
+    paired: set[str],
+) -> dict[str, str]:
+    """Return ``group_id → caption-text`` for paired (figure+caption) groups."""
+    out: dict[str, str] = {}
+    for region in regions:
+        if (
+            region.role is RegionRole.CAPTION
+            and region.group_id is not None
+            and region.group_id in paired
+        ):
+            out[region.group_id] = normalise_text(region.text, form=normalisation).strip()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-role writers
+# ---------------------------------------------------------------------------
+
+
+def _prepare_text(text: str, *, normalisation: NormalisationForm, apply_bidi: bool) -> str:
+    out = normalise_text(text, form=normalisation)
+    if apply_bidi:
+        out = add_rlm_if_needed(out)
+    return out
+
+
+def _add_heading(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    normalisation: NormalisationForm,
+    apply_bidi: bool,
+) -> None:
+    level = region.heading_level if region.heading_level is not None else 2
+    level = max(1, min(level, 9))
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    document.add_paragraph(text, style=f"Heading {level}")
+
+
+def _add_paragraph(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    normalisation: NormalisationForm,
+    apply_bidi: bool,
+) -> None:
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    document.add_paragraph(text, style="Normal")
+
+
+def _add_caption(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    normalisation: NormalisationForm,
+    apply_bidi: bool,
+) -> None:
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    paragraph = document.add_paragraph(style="Normal")
+    run = paragraph.add_run(text)
+    run.italic = True
+
+
+def _add_list_item(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    normalisation: NormalisationForm,
+    apply_bidi: bool,
+) -> None:
+    marker = region.list_marker
+    raw_text = region.text
+    if marker is not None and marker.raw_marker:
+        stripped = raw_text.lstrip()
+        if stripped.startswith(marker.raw_marker):
+            leading_ws = raw_text[: len(raw_text) - len(stripped)]
+            rest = stripped[len(marker.raw_marker) :]
+            if rest.startswith(" "):
+                rest = rest[1:]
+            raw_text = leading_ws + rest
+    text = _prepare_text(raw_text, normalisation=normalisation, apply_bidi=apply_bidi)
+    style = "List Number" if marker is not None and marker.kind == "ordered" else "List Bullet"
+    document.add_paragraph(text, style=style)
+
+
+def _add_failure(document: _DocxDocument, region: Region) -> None:
+    page_n = region.page_index + 1
+    reason = region.failure_reason or "unknown"
+    document.add_paragraph(f"Transcription failed (page {page_n}): {reason}", style="Quote")
+
+
+def _add_figure(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    pending_caption_text: dict[str, str],
+) -> None:
+    page_n = region.page_index + 1
+    text = f"Figure on page {page_n}"
+    if region.group_id is not None and region.group_id in pending_caption_text:
+        caption = pending_caption_text[region.group_id]
+        if caption:
+            text = f"{text}: {caption}"
+    document.add_paragraph(text, style="Normal")
+
+
+def _add_table(
+    document: _DocxDocument,
+    region: Region,
+    *,
+    normalisation: NormalisationForm,
+) -> None:
+    grid: TableGrid | None = region.table_grid
+    if grid is None or grid.n_rows == 0 or grid.n_cols == 0:
+        return
+    if region.meta.get("v1_table_simplification") is True:
+        document.add_paragraph("(v1: merged cells flattened)", style="Normal")
+    table = document.add_table(rows=grid.n_rows, cols=grid.n_cols)
+    for r_idx, row in enumerate(grid.rows):
+        for c_idx in range(grid.n_cols):
+            cell_text = (
+                normalise_text(row[c_idx].text, form=normalisation) if c_idx < len(row) else ""
+            )
+            table.cell(r_idx, c_idx).text = cell_text
+
+
+__all__ = ["emit_docx"]

--- a/src/arabic_pdf_transcribe/emit/markdown.py
+++ b/src/arabic_pdf_transcribe/emit/markdown.py
@@ -1,0 +1,271 @@
+"""Markdown emitter.
+
+Converts an ordered, role-classified :class:`Region` stream into a
+GFM-compatible Markdown document. Pure function: same input → same
+output, no I/O, no environment-dependent data.
+
+Mapping rules (see plan section "Phase 7"):
+
+* ``HEADING`` → ``#`` × ``heading_level`` (defaults to 2 if missing).
+* ``PARAGRAPH`` → plain paragraph (escape-safe).
+* ``LIST_ITEM`` → ``- `` (bullet) or ``N. `` (ordered, ``N`` from
+  ``list_marker.ordinal``); consecutive list items render in the
+  same list block.
+* ``TABLE`` → Markdown pipe-table from ``region.table_grid``;
+  cell text is escape-safe; v1 cells with merged-cell flattening
+  precede the table with ``<!-- v1: merged cells flattened -->``.
+* ``FIGURE`` → ``![alt](#)``; when grouped via ``group_id`` with a
+  ``CAPTION`` region, the caption text is the alt-text and the
+  caption region is suppressed (it was emitted as part of the
+  figure line).
+* ``CAPTION`` (ungrouped) → italic paragraph (``*caption text*``).
+* ``HEADER_FOOTER`` → suppressed.
+* ``FAILURE_PLACEHOLDER`` → HTML comment with the page index and
+  reason.
+* ``UNKNOWN`` → emitted as a plain paragraph (best-effort).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from arabic_pdf_transcribe.emit._bidi import add_rlm_if_needed
+from arabic_pdf_transcribe.emit._md_escape import (
+    escape_paragraph,
+    escape_table_cell,
+)
+from arabic_pdf_transcribe.emit._normalise import (
+    DEFAULT_FORM,
+    NormalisationForm,
+    normalise_text,
+)
+from arabic_pdf_transcribe.regions import (
+    Region,
+    RegionRole,
+    TableGrid,
+)
+
+_BLOCK_SEPARATOR = "\n\n"
+
+
+def emit_markdown(
+    regions: Iterable[Region],
+    *,
+    normalisation: NormalisationForm = DEFAULT_FORM,
+    apply_bidi: bool = True,
+) -> str:
+    """Render ``regions`` as Markdown.
+
+    Parameters
+    ----------
+    regions:
+        Iterable of role-classified regions in reading order.
+    normalisation:
+        Unicode normalisation form. ``"NFC"`` (default) preserves
+        Arabic presentation forms; ``"NFKC"`` collapses them — see
+        :mod:`arabic_pdf_transcribe.emit._normalise`.
+    apply_bidi:
+        When ``True`` (default), Arabic-dominant paragraphs that
+        contain LTR runs get a leading U+200F RLM mark for stable
+        rendering on permissive bidi engines.
+    """
+    region_list = list(regions)
+    caption_group_ids = _collect_paired_caption_group_ids(region_list)
+    blocks: list[str] = []
+    pending_list: list[str] = []
+    for region in region_list:
+        rendered_list_item = _render_list_item(region, normalisation, apply_bidi)
+        if rendered_list_item is not None:
+            pending_list.append(rendered_list_item)
+            continue
+        if pending_list:
+            blocks.append("\n".join(pending_list))
+            pending_list = []
+        block = _render_block(
+            region,
+            caption_group_ids=caption_group_ids,
+            region_list=region_list,
+            normalisation=normalisation,
+            apply_bidi=apply_bidi,
+        )
+        if block:
+            blocks.append(block)
+    if pending_list:
+        blocks.append("\n".join(pending_list))
+    return _BLOCK_SEPARATOR.join(blocks) + ("\n" if blocks else "")
+
+
+# ---------------------------------------------------------------------------
+# Block dispatch
+# ---------------------------------------------------------------------------
+
+
+def _collect_paired_caption_group_ids(regions: Sequence[Region]) -> set[str]:
+    """Return ``group_id``s where BOTH a caption and figure exist.
+
+    Captions are suppressed during the main pass only when there is a
+    paired figure that will consume their text. An orphan grouped
+    caption (no matching figure) still renders as a caption so the
+    text is not dropped.
+    """
+    figure_ids = {
+        region.group_id
+        for region in regions
+        if region.role is RegionRole.FIGURE and region.group_id is not None
+    }
+    caption_ids = {
+        region.group_id
+        for region in regions
+        if region.role is RegionRole.CAPTION and region.group_id is not None
+    }
+    return figure_ids & caption_ids
+
+
+def _render_block(
+    region: Region,
+    *,
+    caption_group_ids: set[str],
+    region_list: Sequence[Region],
+    normalisation: NormalisationForm,
+    apply_bidi: bool,
+) -> str | None:
+    role = region.role
+    if role is RegionRole.HEADER_FOOTER:
+        return None
+    if role is RegionRole.CAPTION and region.group_id in caption_group_ids:
+        # Already rendered as the figure's alt-text.
+        return None
+    if role is RegionRole.HEADING:
+        return _render_heading(region, normalisation, apply_bidi)
+    if role is RegionRole.TABLE:
+        return _render_table(region, normalisation)
+    if role is RegionRole.FIGURE:
+        return _render_figure(region, region_list=region_list, normalisation=normalisation)
+    if role is RegionRole.CAPTION:
+        return _render_caption(region, normalisation, apply_bidi)
+    if role is RegionRole.FAILURE_PLACEHOLDER:
+        return _render_failure(region)
+    # PARAGRAPH / UNKNOWN.
+    return _render_paragraph(region, normalisation, apply_bidi)
+
+
+# ---------------------------------------------------------------------------
+# Per-role renderers
+# ---------------------------------------------------------------------------
+
+
+def _prepare_text(text: str, *, normalisation: NormalisationForm, apply_bidi: bool) -> str:
+    out = normalise_text(text, form=normalisation)
+    if apply_bidi:
+        out = add_rlm_if_needed(out)
+    return out
+
+
+def _render_heading(region: Region, normalisation: NormalisationForm, apply_bidi: bool) -> str:
+    level = region.heading_level if region.heading_level is not None else 2
+    level = max(1, min(level, 6))
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    return f"{'#' * level} {escape_paragraph(text).strip()}"
+
+
+def _render_paragraph(region: Region, normalisation: NormalisationForm, apply_bidi: bool) -> str:
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    return escape_paragraph(text)
+
+
+def _render_caption(region: Region, normalisation: NormalisationForm, apply_bidi: bool) -> str:
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    inner = escape_paragraph(text).strip()
+    if not inner:
+        return ""
+    return f"*{inner}*"
+
+
+def _render_failure(region: Region) -> str:
+    reason = region.failure_reason or "unknown"
+    page_n = region.page_index + 1
+    safe_reason = reason.replace("--", "- -")
+    return f"<!-- transcription-failed: page {page_n} reason: {safe_reason} -->"
+
+
+def _render_list_item(
+    region: Region, normalisation: NormalisationForm, apply_bidi: bool
+) -> str | None:
+    if region.role is not RegionRole.LIST_ITEM:
+        return None
+    marker = region.list_marker
+    text = _prepare_text(region.text, normalisation=normalisation, apply_bidi=apply_bidi)
+    body = escape_paragraph(_strip_leading_marker(text, marker)).strip()
+    if marker is not None and marker.kind == "ordered" and marker.ordinal is not None:
+        return f"{marker.ordinal}. {body}"
+    return f"- {body}"
+
+
+def _strip_leading_marker(text: str, marker: object) -> str:
+    """Drop the raw marker prefix from ``text`` if present.
+
+    Phase 6 stamps the marker but does not edit the text. The
+    Markdown emitter re-emits the marker in canonical form, so the
+    raw prefix is stripped here to avoid double-marker output (e.g.
+    ``- - text``).
+    """
+    if marker is None:
+        return text
+    raw = getattr(marker, "raw_marker", None)
+    if not raw:
+        return text
+    stripped = text.lstrip()
+    leading_ws = text[: len(text) - len(stripped)]
+    if stripped.startswith(raw):
+        rest = stripped[len(raw) :]
+        # Eat one separator space if present.
+        if rest.startswith(" "):
+            rest = rest[1:]
+        return leading_ws + rest
+    return text
+
+
+def _render_figure(
+    region: Region,
+    *,
+    region_list: Sequence[Region],
+    normalisation: NormalisationForm,
+) -> str:
+    page_n = region.page_index + 1
+    alt = f"figure on page {page_n}"
+    if region.group_id is not None:
+        for other in region_list:
+            if other.role is RegionRole.CAPTION and other.group_id == region.group_id:
+                cap_text = normalise_text(other.text, form=normalisation).strip()
+                if cap_text:
+                    alt = cap_text
+                break
+    safe_alt = alt.replace("[", "\\[").replace("]", "\\]")
+    return f"![{safe_alt}](#)"
+
+
+def _render_table(region: Region, normalisation: NormalisationForm) -> str:
+    grid: TableGrid | None = region.table_grid
+    if grid is None or grid.n_rows == 0 or grid.n_cols == 0:
+        return ""
+    n_cols = grid.n_cols
+    rows: list[str] = []
+    for row in grid.rows:
+        cells = [escape_table_cell(normalise_text(cell.text, form=normalisation)) for cell in row]
+        # Pad short rows so every output row has the same column count.
+        while len(cells) < n_cols:
+            cells.append("")
+        rows.append("| " + " | ".join(cells) + " |")
+    if not rows:
+        return ""
+    header_row = rows[0]
+    separator = "| " + " | ".join(["---"] * n_cols) + " |"
+    body_rows = rows[1:]
+    table_lines = [header_row, separator, *body_rows]
+    table = "\n".join(table_lines)
+    if region.meta.get("v1_table_simplification") is True:
+        return "<!-- v1: merged cells flattened -->\n" + table
+    return table
+
+
+__all__ = ["emit_markdown"]

--- a/tests/test_emit_bidi.py
+++ b/tests/test_emit_bidi.py
@@ -1,0 +1,77 @@
+"""Phase-7 bidi helper tests."""
+
+from __future__ import annotations
+
+from arabic_pdf_transcribe.emit._bidi import (
+    RLM,
+    add_rlm_if_needed,
+    has_ltr_run,
+    is_arabic_dominant,
+)
+
+
+def test_pure_arabic_is_arabic_dominant() -> None:
+    assert is_arabic_dominant("السلام عليكم")
+
+
+def test_pure_latin_is_not_arabic_dominant() -> None:
+    assert not is_arabic_dominant("Hello world")
+
+
+def test_empty_text_is_not_arabic_dominant() -> None:
+    assert not is_arabic_dominant("")
+
+
+def test_majority_arabic_with_latin_run_is_arabic_dominant() -> None:
+    text = "اللغة العربية هي Arabic"
+    assert is_arabic_dominant(text)
+
+
+def test_minority_arabic_is_not_dominant() -> None:
+    text = "the word for Arabic is عربي"
+    assert not is_arabic_dominant(text)
+
+
+def test_has_ltr_run_detects_latin() -> None:
+    assert has_ltr_run("Arabic")
+
+
+def test_has_ltr_run_no_latin() -> None:
+    assert not has_ltr_run("السلام")
+
+
+def test_add_rlm_inserts_when_arabic_with_ltr() -> None:
+    text = "اللغة العربية هي Arabic"
+    out = add_rlm_if_needed(text)
+    assert out.startswith(RLM)
+    assert out[1:] == text
+
+
+def test_add_rlm_no_change_for_pure_arabic() -> None:
+    text = "السلام عليكم"
+    assert add_rlm_if_needed(text) == text
+
+
+def test_add_rlm_no_change_for_pure_latin() -> None:
+    text = "Hello world"
+    assert add_rlm_if_needed(text) == text
+
+
+def test_add_rlm_idempotent() -> None:
+    text = "اللغة hello"
+    once = add_rlm_if_needed(text)
+    twice = add_rlm_if_needed(once)
+    assert once == twice
+
+
+def test_add_rlm_handles_empty() -> None:
+    assert add_rlm_if_needed("") == ""
+
+
+def test_rlm_constant_is_u200f() -> None:
+    assert RLM == "‏"
+
+
+def test_bidi_class_check_is_pure() -> None:
+    text = "السلام Arabic"
+    assert add_rlm_if_needed(text) == add_rlm_if_needed(text)

--- a/tests/test_emit_docx.py
+++ b/tests/test_emit_docx.py
@@ -1,0 +1,312 @@
+"""Phase-7 docx emitter structural tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from arabic_pdf_transcribe.emit import emit_docx
+from arabic_pdf_transcribe.regions import (
+    BBox,
+    ListMarker,
+    Region,
+    RegionRole,
+    RegionSource,
+    TableCell,
+    TableGrid,
+)
+
+
+def _region(
+    *,
+    role: RegionRole = RegionRole.PARAGRAPH,
+    text: str = "",
+    page_index: int = 0,
+    heading_level: int | None = None,
+    list_marker: ListMarker | None = None,
+    table_grid: TableGrid | None = None,
+    group_id: str | None = None,
+    failure_reason: str | None = None,
+) -> Region:
+    return Region(
+        page_index=page_index,
+        bbox=BBox(0.0, 0.0, 100.0, 30.0),
+        text=text,
+        role=role,
+        source=RegionSource.NATIVE,
+        heading_level=heading_level,
+        list_marker=list_marker,
+        table_grid=table_grid,
+        group_id=group_id,
+        failure_reason=failure_reason,
+    )
+
+
+def _open(path: Path):
+    from docx import Document
+
+    return Document(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Per-role style assertions
+# ---------------------------------------------------------------------------
+
+
+def test_paragraph_uses_normal_style(tmp_path: Path) -> None:
+    out = tmp_path / "out.docx"
+    emit_docx([_region(text="hi")], out)
+    doc = _open(out)
+    paras = list(doc.paragraphs)
+    assert len(paras) == 1
+    assert paras[0].text == "hi"
+    assert paras[0].style.name == "Normal"
+
+
+def test_heading_uses_heading_style_with_level(tmp_path: Path) -> None:
+    out = tmp_path / "h.docx"
+    regions = [
+        _region(role=RegionRole.HEADING, text="A", heading_level=1),
+        _region(role=RegionRole.HEADING, text="B", heading_level=2),
+        _region(role=RegionRole.HEADING, text="C", heading_level=3),
+    ]
+    emit_docx(regions, out)
+    doc = _open(out)
+    styles = [p.style.name for p in doc.paragraphs]
+    assert "Heading 1" in styles
+    assert "Heading 2" in styles
+    assert "Heading 3" in styles
+
+
+def test_heading_default_level_is_2(tmp_path: Path) -> None:
+    out = tmp_path / "h2.docx"
+    emit_docx(
+        [_region(role=RegionRole.HEADING, text="X", heading_level=None)],
+        out,
+    )
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.style.name == "Heading 2"
+
+
+def test_bullet_list_item_uses_list_bullet_style(tmp_path: Path) -> None:
+    out = tmp_path / "l.docx"
+    r = _region(
+        role=RegionRole.LIST_ITEM,
+        text="- one",
+        list_marker=ListMarker(kind="bullet", raw_marker="-"),
+    )
+    emit_docx([r], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.style.name == "List Bullet"
+    # Marker stripped before emission.
+    assert p.text == "one"
+
+
+def test_ordered_list_item_uses_list_number_style(tmp_path: Path) -> None:
+    out = tmp_path / "o.docx"
+    r = _region(
+        role=RegionRole.LIST_ITEM,
+        text="3) third",
+        list_marker=ListMarker(kind="ordered", ordinal=3, raw_marker="3)"),
+    )
+    emit_docx([r], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.style.name == "List Number"
+
+
+def test_caption_paragraph_is_italic(tmp_path: Path) -> None:
+    out = tmp_path / "c.docx"
+    emit_docx([_region(role=RegionRole.CAPTION, text="cap")], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.text == "cap"
+    [run] = p.runs
+    assert run.italic is True
+
+
+def test_failure_uses_quote_style(tmp_path: Path) -> None:
+    out = tmp_path / "f.docx"
+    r = _region(
+        role=RegionRole.FAILURE_PLACEHOLDER,
+        page_index=4,
+        failure_reason="ocr_failed",
+    )
+    emit_docx([r], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.style.name == "Quote"
+    assert "page 5" in p.text
+    assert "ocr_failed" in p.text
+
+
+def test_header_footer_is_suppressed(tmp_path: Path) -> None:
+    out = tmp_path / "hf.docx"
+    emit_docx([_region(role=RegionRole.HEADER_FOOTER, text="page 1")], out)
+    doc = _open(out)
+    assert len(list(doc.paragraphs)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+def _grid(rows: list[list[str]]) -> TableGrid:
+    return TableGrid(
+        rows=tuple(
+            tuple(TableCell(text=cell, confidence=None, bbox=BBox(0, 0, 10, 10)) for cell in row)
+            for row in rows
+        )
+    )
+
+
+def test_table_emits_word_table(tmp_path: Path) -> None:
+    out = tmp_path / "t.docx"
+    grid = _grid([["h1", "h2"], ["a", "b"]])
+    emit_docx([_region(role=RegionRole.TABLE, table_grid=grid)], out)
+    doc = _open(out)
+    [table] = doc.tables
+    assert len(table.rows) == 2
+    assert len(table.columns) == 2
+    assert table.cell(0, 0).text == "h1"
+    assert table.cell(1, 1).text == "b"
+
+
+def test_table_short_row_padded(tmp_path: Path) -> None:
+    out = tmp_path / "t2.docx"
+    grid = _grid([["a", "b", "c"], ["x"]])
+    emit_docx([_region(role=RegionRole.TABLE, table_grid=grid)], out)
+    doc = _open(out)
+    [table] = doc.tables
+    assert len(table.columns) == 3
+    assert table.cell(1, 1).text == ""
+    assert table.cell(1, 2).text == ""
+
+
+# ---------------------------------------------------------------------------
+# Figures + grouping
+# ---------------------------------------------------------------------------
+
+
+def test_figure_without_group_emits_placeholder(tmp_path: Path) -> None:
+    out = tmp_path / "fig.docx"
+    emit_docx([_region(role=RegionRole.FIGURE, page_index=2)], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.text == "Figure on page 3"
+
+
+def test_orphan_grouped_caption_still_renders(tmp_path: Path) -> None:
+    """Regression: grouped caption without a matching figure must
+    still be written as a caption paragraph."""
+    out = tmp_path / "orphan.docx"
+    cap = _region(role=RegionRole.CAPTION, text="orphan", group_id="solo")
+    emit_docx([cap], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.text == "orphan"
+    [run] = p.runs
+    assert run.italic is True
+
+
+def test_grouped_figure_caption_combined(tmp_path: Path) -> None:
+    out = tmp_path / "fig2.docx"
+    fig = _region(role=RegionRole.FIGURE, page_index=0, group_id="g1")
+    cap = _region(role=RegionRole.CAPTION, text="A horse", group_id="g1")
+    emit_docx([fig, cap], out)
+    doc = _open(out)
+    paras = [p.text for p in doc.paragraphs]
+    # Caption suppressed, figure paragraph carries the caption text.
+    assert paras == ["Figure on page 1: A horse"]
+
+
+# ---------------------------------------------------------------------------
+# Network purity
+# ---------------------------------------------------------------------------
+
+
+def test_emit_docx_performs_no_network_io(tmp_path: Path) -> None:
+    """Acceptance criterion: emitter performs no network I/O.
+
+    We patch ``socket.socket`` to raise on instantiation; if the
+    emitter or any dep tries to create a socket the test fails.
+    """
+    out = tmp_path / "net.docx"
+    regions = [
+        _region(role=RegionRole.HEADING, text="t", heading_level=1),
+        _region(text="prose"),
+    ]
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("network access forbidden during emit")
+
+    with patch("socket.socket", new=boom):
+        emit_docx(regions, out)
+    assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_two_runs_produce_byte_identical_xml(tmp_path: Path) -> None:
+    """python-docx writes timestamps inside core.xml, but document.xml
+    (the body) should be byte-identical across runs for the same
+    input. We check document.xml only.
+    """
+    import zipfile
+
+    regions = [
+        _region(role=RegionRole.HEADING, text="t", heading_level=1),
+        _region(text="prose"),
+    ]
+    a = tmp_path / "a.docx"
+    b = tmp_path / "b.docx"
+    emit_docx(regions, a)
+    emit_docx(regions, b)
+    with zipfile.ZipFile(a) as za, zipfile.ZipFile(b) as zb:
+        assert za.read("word/document.xml") == zb.read("word/document.xml")
+
+
+# ---------------------------------------------------------------------------
+# String path acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_string_path_accepted(tmp_path: Path) -> None:
+    out = str(tmp_path / "s.docx")
+    emit_docx([_region(text="x")], out)
+    assert Path(out).exists()
+
+
+def test_empty_input_writes_empty_doc(tmp_path: Path) -> None:
+    out = tmp_path / "e.docx"
+    emit_docx([], out)
+    assert out.exists()
+    doc = _open(out)
+    assert len(list(doc.paragraphs)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Pyright import smoke (no test logic, just ensures module loads)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_docx_callable() -> None:
+    assert callable(emit_docx)
+
+
+@pytest.mark.parametrize("level", [1, 2, 3, 4, 5, 6, 9])
+def test_heading_levels_clamp_to_word_max(tmp_path: Path, level: int) -> None:
+    out = tmp_path / f"h{level}.docx"
+    r = _region(role=RegionRole.HEADING, text="X", heading_level=level)
+    emit_docx([r], out)
+    doc = _open(out)
+    [p] = list(doc.paragraphs)
+    assert p.style.name == f"Heading {level}"

--- a/tests/test_emit_lazy_import.py
+++ b/tests/test_emit_lazy_import.py
@@ -1,0 +1,58 @@
+"""Phase-7 lazy-import regression: emit package must not load docx eagerly.
+
+``python-docx`` is only needed by the docx emitter. Importing
+``arabic_pdf_transcribe.emit`` (or any of its non-docx submodules)
+must not pull ``docx`` into ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+HEAVY_MODULES = ("docx",)
+
+
+def _import_and_dump_modules(import_target: str) -> set[str]:
+    code = (
+        "import sys, json\n"
+        f"import {import_target}\n"
+        "print(json.dumps([m for m in sys.modules]))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return set(json.loads(proc.stdout))
+
+
+def _leaks(loaded: set[str]) -> list[str]:
+    return [m for m in HEAVY_MODULES if any(k == m or k.startswith(m + ".") for k in loaded)]
+
+
+def test_importing_emit_package_does_not_load_docx() -> None:
+    loaded = _import_and_dump_modules("arabic_pdf_transcribe.emit")
+    assert _leaks(loaded) == [], f"emit package leaked: {_leaks(loaded)}"
+
+
+def test_importing_markdown_module_does_not_load_docx() -> None:
+    loaded = _import_and_dump_modules("arabic_pdf_transcribe.emit.markdown")
+    assert _leaks(loaded) == [], f"emit.markdown leaked: {_leaks(loaded)}"
+
+
+def test_importing_normalise_module_does_not_load_docx() -> None:
+    loaded = _import_and_dump_modules("arabic_pdf_transcribe.emit._normalise")
+    assert _leaks(loaded) == [], f"emit._normalise leaked: {_leaks(loaded)}"
+
+
+def test_importing_bidi_module_does_not_load_docx() -> None:
+    loaded = _import_and_dump_modules("arabic_pdf_transcribe.emit._bidi")
+    assert _leaks(loaded) == [], f"emit._bidi leaked: {_leaks(loaded)}"
+
+
+def test_importing_md_escape_module_does_not_load_docx() -> None:
+    loaded = _import_and_dump_modules("arabic_pdf_transcribe.emit._md_escape")
+    assert _leaks(loaded) == [], f"emit._md_escape leaked: {_leaks(loaded)}"

--- a/tests/test_emit_markdown.py
+++ b/tests/test_emit_markdown.py
@@ -1,0 +1,379 @@
+"""Phase-7 Markdown emitter tests."""
+
+from __future__ import annotations
+
+from arabic_pdf_transcribe.emit import emit_markdown
+from arabic_pdf_transcribe.regions import (
+    BBox,
+    ListMarker,
+    Region,
+    RegionRole,
+    RegionSource,
+    TableCell,
+    TableGrid,
+)
+
+
+def _region(
+    *,
+    role: RegionRole = RegionRole.PARAGRAPH,
+    text: str = "",
+    page_index: int = 0,
+    heading_level: int | None = None,
+    list_marker: ListMarker | None = None,
+    table_grid: TableGrid | None = None,
+    group_id: str | None = None,
+    failure_reason: str | None = None,
+    bbox: BBox = BBox(0.0, 0.0, 100.0, 30.0),
+    meta: dict[str, object] | None = None,
+) -> Region:
+    region = Region(
+        page_index=page_index,
+        bbox=bbox,
+        text=text,
+        role=role,
+        source=RegionSource.NATIVE,
+        heading_level=heading_level,
+        list_marker=list_marker,
+        table_grid=table_grid,
+        group_id=group_id,
+        failure_reason=failure_reason,
+    )
+    if meta:
+        region = region.with_meta(**meta)
+    return region
+
+
+# ---------------------------------------------------------------------------
+# Empty + role mappings
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_string() -> None:
+    assert emit_markdown([]) == ""
+
+
+def test_paragraph_emits_plain_text() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="hello world")
+    assert emit_markdown([r]) == "hello world\n"
+
+
+def test_heading_emits_hash_prefix() -> None:
+    r = _region(role=RegionRole.HEADING, text="Title", heading_level=1)
+    assert emit_markdown([r]) == "# Title\n"
+
+
+def test_heading_default_level_is_h2_when_missing() -> None:
+    r = _region(role=RegionRole.HEADING, text="Title", heading_level=None)
+    assert emit_markdown([r]) == "## Title\n"
+
+
+def test_heading_level_capped_at_h6() -> None:
+    r = _region(role=RegionRole.HEADING, text="X", heading_level=99)
+    assert emit_markdown([r]) == "###### X\n"
+
+
+def test_heading_level_floored_at_h1() -> None:
+    r = _region(role=RegionRole.HEADING, text="X", heading_level=0)
+    assert emit_markdown([r]) == "# X\n"
+
+
+def test_caption_ungrouped_emits_italic_paragraph() -> None:
+    r = _region(role=RegionRole.CAPTION, text="A caption")
+    assert emit_markdown([r]) == "*A caption*\n"
+
+
+def test_header_footer_is_suppressed() -> None:
+    r = _region(role=RegionRole.HEADER_FOOTER, text="page 1")
+    assert emit_markdown([r]) == ""
+
+
+def test_failure_placeholder_emits_html_comment() -> None:
+    r = _region(
+        role=RegionRole.FAILURE_PLACEHOLDER,
+        page_index=4,
+        failure_reason="ocr_failed",
+    )
+    out = emit_markdown([r])
+    assert "<!--" in out
+    assert "page 5" in out  # 1-based
+    assert "ocr_failed" in out
+
+
+def test_unknown_role_emits_as_paragraph() -> None:
+    r = _region(role=RegionRole.UNKNOWN, text="orphan")
+    assert emit_markdown([r]) == "orphan\n"
+
+
+# ---------------------------------------------------------------------------
+# List items
+# ---------------------------------------------------------------------------
+
+
+def test_bullet_list_item() -> None:
+    r = _region(
+        role=RegionRole.LIST_ITEM,
+        text="- first",
+        list_marker=ListMarker(kind="bullet", raw_marker="-"),
+    )
+    assert emit_markdown([r]) == "- first\n"
+
+
+def test_ordered_list_item_uses_ordinal() -> None:
+    r = _region(
+        role=RegionRole.LIST_ITEM,
+        text="3) third",
+        list_marker=ListMarker(kind="ordered", ordinal=3, raw_marker="3)"),
+    )
+    assert emit_markdown([r]) == "3. third\n"
+
+
+def test_consecutive_list_items_share_block() -> None:
+    items = [
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- a",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- b",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- c",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+    ]
+    out = emit_markdown(items)
+    assert out == "- a\n- b\n- c\n"
+
+
+def test_list_then_paragraph_breaks_block() -> None:
+    regions = [
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- a",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(role=RegionRole.PARAGRAPH, text="prose"),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- b",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+    ]
+    out = emit_markdown(regions)
+    assert out == "- a\n\nprose\n\n- b\n"
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+def _grid(rows: list[list[str]]) -> TableGrid:
+    return TableGrid(
+        rows=tuple(
+            tuple(TableCell(text=cell, confidence=None, bbox=BBox(0, 0, 10, 10)) for cell in row)
+            for row in rows
+        )
+    )
+
+
+def test_table_emits_pipe_table() -> None:
+    grid = _grid([["h1", "h2"], ["a", "b"]])
+    r = _region(role=RegionRole.TABLE, table_grid=grid)
+    out = emit_markdown([r])
+    assert "| h1 | h2 |" in out
+    assert "| --- | --- |" in out
+    assert "| a | b |" in out
+
+
+def test_table_pipes_in_cells_escaped() -> None:
+    grid = _grid([["h1"], ["x | y"]])
+    r = _region(role=RegionRole.TABLE, table_grid=grid)
+    out = emit_markdown([r])
+    assert r"x \| y" in out
+
+
+def test_table_v1_simplification_emits_comment() -> None:
+    grid = _grid([["a", "b"]])
+    r = _region(
+        role=RegionRole.TABLE,
+        table_grid=grid,
+        meta={"v1_table_simplification": True},
+    )
+    out = emit_markdown([r])
+    assert "<!-- v1: merged cells flattened -->" in out
+
+
+def test_table_short_row_padded_to_n_cols() -> None:
+    grid = _grid([["a", "b", "c"], ["x"]])
+    r = _region(role=RegionRole.TABLE, table_grid=grid)
+    out = emit_markdown([r])
+    assert "| x |  |  |" in out
+
+
+def test_table_empty_grid_emits_nothing() -> None:
+    r = _region(role=RegionRole.TABLE, table_grid=TableGrid(rows=()))
+    out = emit_markdown([r])
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Figures + captions
+# ---------------------------------------------------------------------------
+
+
+def test_figure_without_group_uses_default_alt() -> None:
+    r = _region(role=RegionRole.FIGURE, page_index=2)
+    out = emit_markdown([r])
+    assert out == "![figure on page 3](#)\n"
+
+
+def test_grouped_figure_caption_pair_uses_caption_as_alt() -> None:
+    fig = _region(role=RegionRole.FIGURE, page_index=0, group_id="g1")
+    cap = _region(role=RegionRole.CAPTION, text="A horse", group_id="g1")
+    out = emit_markdown([fig, cap])
+    assert "![A horse](#)" in out
+    # Caption suppressed (no italic line).
+    assert "*A horse*" not in out
+
+
+def test_orphan_grouped_caption_still_renders() -> None:
+    """Regression: caption with group_id but no matching figure must
+    still emit as a caption — otherwise text is lost."""
+    cap = _region(role=RegionRole.CAPTION, text="orphan", group_id="solo")
+    out = emit_markdown([cap])
+    assert "*orphan*" in out
+
+
+def test_caption_brackets_in_alt_text_escaped() -> None:
+    fig = _region(role=RegionRole.FIGURE, group_id="g1")
+    cap = _region(role=RegionRole.CAPTION, text="[bracketed]", group_id="g1")
+    out = emit_markdown([fig, cap])
+    assert r"\[bracketed\]" in out
+
+
+# ---------------------------------------------------------------------------
+# Adversarial text
+# ---------------------------------------------------------------------------
+
+
+def test_paragraph_starting_with_hash_is_escaped() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="# not a heading")
+    out = emit_markdown([r])
+    assert out == "\\# not a heading\n"
+
+
+def test_paragraph_starting_with_dash_is_escaped() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="- not a bullet")
+    out = emit_markdown([r])
+    assert out == "\\- not a bullet\n"
+
+
+def test_paragraph_with_pipes_is_safe_outside_table() -> None:
+    """Pipes outside tables don't need escaping in standard Markdown,
+    but they should at least not crash the emitter."""
+    r = _region(role=RegionRole.PARAGRAPH, text="a | b | c")
+    out = emit_markdown([r])
+    assert out == "a | b | c\n"
+
+
+def test_paragraph_with_inline_emphasis_chars_escaped() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="**bold** _italic_")
+    out = emit_markdown([r])
+    assert out == r"\*\*bold\*\* \_italic\_" + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Bidi + normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_arabic_with_latin_gets_rlm_prefix() -> None:
+    r = _region(
+        role=RegionRole.PARAGRAPH,
+        text="هذه كلمة Arabic في اللغة",
+    )
+    out = emit_markdown([r])
+    assert out.startswith("‏")
+
+
+def test_pure_arabic_no_rlm() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="السلام عليكم")
+    out = emit_markdown([r])
+    assert "‏" not in out
+
+
+def test_apply_bidi_false_skips_rlm() -> None:
+    r = _region(role=RegionRole.PARAGRAPH, text="هذه Arabic")
+    out = emit_markdown([r], apply_bidi=False)
+    assert "‏" not in out
+
+
+def test_nfkc_collapses_allah_ligature() -> None:
+    """Verifies opt-in NFKC routes through the emitter."""
+    r = _region(role=RegionRole.PARAGRAPH, text="ﷲ")
+    nfc_out = emit_markdown([r], normalisation="NFC", apply_bidi=False)
+    nfkc_out = emit_markdown([r], normalisation="NFKC", apply_bidi=False)
+    assert nfc_out != nfkc_out
+    # NFKC expansion is longer.
+    assert len(nfkc_out) > len(nfc_out)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_emit_markdown_byte_identical_across_runs() -> None:
+    """Acceptance criterion: snapshot stability."""
+    regions = [
+        _region(role=RegionRole.HEADING, text="Chapter 1", heading_level=1),
+        _region(role=RegionRole.PARAGRAPH, text="Some prose."),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- a",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- b",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+    ]
+    a = emit_markdown(regions)
+    b = emit_markdown(regions)
+    assert a == b
+
+
+def test_full_document_snapshot() -> None:
+    """End-to-end multi-role rendering snapshot."""
+    grid = _grid([["A", "B"], ["1", "2"]])
+    regions = [
+        _region(role=RegionRole.HEADING, text="Title", heading_level=1),
+        _region(role=RegionRole.PARAGRAPH, text="intro paragraph"),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- one",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(
+            role=RegionRole.LIST_ITEM,
+            text="- two",
+            list_marker=ListMarker(kind="bullet", raw_marker="-"),
+        ),
+        _region(role=RegionRole.HEADING, text="Section", heading_level=2),
+        _region(role=RegionRole.TABLE, table_grid=grid),
+    ]
+    expected = (
+        "# Title\n\n"
+        "intro paragraph\n\n"
+        "- one\n- two\n\n"
+        "## Section\n\n"
+        "| A | B |\n| --- | --- |\n| 1 | 2 |\n"
+    )
+    assert emit_markdown(regions) == expected

--- a/tests/test_emit_md_escape.py
+++ b/tests/test_emit_md_escape.py
@@ -1,0 +1,70 @@
+"""Phase-7 markdown-escape tests."""
+
+from __future__ import annotations
+
+from arabic_pdf_transcribe.emit._md_escape import (
+    escape_inline,
+    escape_paragraph,
+    escape_table_cell,
+)
+
+
+def test_escape_inline_passes_arabic_through() -> None:
+    text = "السلام عليكم"
+    assert escape_inline(text) == text
+
+
+def test_escape_inline_escapes_asterisk() -> None:
+    assert escape_inline("**bold**") == r"\*\*bold\*\*"
+
+
+def test_escape_inline_escapes_backtick_and_underscore() -> None:
+    assert escape_inline("`x` _y_") == r"\`x\` \_y\_"
+
+
+def test_escape_inline_escapes_brackets() -> None:
+    assert escape_inline("[link](url)") == r"\[link\](url)"
+
+
+def test_escape_paragraph_neutralises_leading_heading() -> None:
+    assert escape_paragraph("# not a heading") == r"\# not a heading"
+
+
+def test_escape_paragraph_neutralises_leading_bullet() -> None:
+    assert escape_paragraph("- not a bullet") == r"\- not a bullet"
+
+
+def test_escape_paragraph_neutralises_leading_blockquote() -> None:
+    assert escape_paragraph("> not a quote") == r"\> not a quote"
+
+
+def test_escape_paragraph_neutralises_leading_ordered_list() -> None:
+    assert escape_paragraph("1. not a list") == r"\1. not a list"
+    assert escape_paragraph("12) still not") == r"\12) still not"
+
+
+def test_escape_paragraph_multi_line_protects_each_line() -> None:
+    out = escape_paragraph("first line\n# second line\nthird")
+    assert out == "first line\n\\# second line\nthird"
+
+
+def test_escape_paragraph_passes_arabic() -> None:
+    text = "هذه فقرة عربية"
+    assert escape_paragraph(text) == text
+
+
+def test_escape_table_cell_escapes_pipes() -> None:
+    assert escape_table_cell("a | b") == r"a \| b"
+
+
+def test_escape_table_cell_escapes_newlines_to_br() -> None:
+    assert escape_table_cell("a\nb") == "a<br>b"
+
+
+def test_escape_table_cell_escapes_inline_syntax() -> None:
+    assert escape_table_cell("**bold**") == r"\*\*bold\*\*"
+
+
+def test_escape_paragraph_idempotent_on_safe_text() -> None:
+    safe = "ordinary prose"
+    assert escape_paragraph(safe) == safe

--- a/tests/test_emit_normalise.py
+++ b/tests/test_emit_normalise.py
@@ -1,0 +1,92 @@
+"""Phase-7 normalisation tests.
+
+Verifies the architect's NFC-default decision: presentation forms
+preserved by default, collapsed only under explicit NFKC opt-in.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from arabic_pdf_transcribe.emit._normalise import (
+    DEFAULT_FORM,
+    normalise_text,
+)
+
+# U+FDF2: ARABIC LIGATURE ALLAH ISOLATED FORM (presentation form)
+ALLAH_LIGATURE = "ﷲ"
+
+# U+FEFB: ARABIC LIGATURE LAM WITH ALEF ISOLATED FORM
+LAM_ALEF_LIGATURE = "ﻻ"
+
+# Decomposed sequence: ALEF + COMBINING HAMZA ABOVE = U+0623 (canonical)
+DECOMPOSED_ALEF_HAMZA = "أ"  # ا + ٔ
+COMPOSED_ALEF_HAMZA = "أ"  # أ
+
+
+def test_default_is_nfc() -> None:
+    assert DEFAULT_FORM == "NFC"
+
+
+def test_nfc_preserves_allah_ligature() -> None:
+    """Architect decision: NFC must NOT collapse U+FDF2 to base letters."""
+    assert normalise_text(ALLAH_LIGATURE) == ALLAH_LIGATURE
+
+
+def test_nfc_preserves_lam_alef_ligature() -> None:
+    assert normalise_text(LAM_ALEF_LIGATURE) == LAM_ALEF_LIGATURE
+
+
+def test_nfkc_collapses_allah_ligature() -> None:
+    """Opt-in NFKC must collapse U+FDF2 into the base letter sequence."""
+    out = normalise_text(ALLAH_LIGATURE, form="NFKC")
+    assert out != ALLAH_LIGATURE
+    # Decomposes to a 4-char sequence
+    assert len(out) >= 3
+
+
+def test_nfc_recomposes_canonical_sequences() -> None:
+    """Decomposed ا + ٔ should canonical-compose to أ under NFC."""
+    out = normalise_text(DECOMPOSED_ALEF_HAMZA)
+    assert out == COMPOSED_ALEF_HAMZA
+
+
+def test_empty_input() -> None:
+    assert normalise_text("") == ""
+
+
+def test_latin_text_passthrough_under_nfc() -> None:
+    assert normalise_text("Hello world") == "Hello world"
+
+
+def test_nfkc_collapses_latin_full_width_digits() -> None:
+    full_width_one = "１"  # FULLWIDTH DIGIT ONE
+    out = normalise_text(full_width_one, form="NFKC")
+    assert out == "1"
+
+
+def test_normalise_is_pure() -> None:
+    text = ALLAH_LIGATURE + " test"
+    assert normalise_text(text) == normalise_text(text)
+
+
+def test_arabic_presentation_form_b_preserved_under_nfc() -> None:
+    """U+FE70..U+FEFF range stays intact under NFC."""
+    contextual = "ﺎ"  # ARABIC LETTER ALEF FINAL FORM
+    assert normalise_text(contextual) == contextual
+    # And NFKC collapses it.
+    assert normalise_text(contextual, form="NFKC") != contextual
+
+
+def test_normalize_idempotent() -> None:
+    text = "تجربة " + ALLAH_LIGATURE
+    once = normalise_text(text)
+    twice = normalise_text(once)
+    assert once == twice
+
+
+def test_unicodedata_consistency() -> None:
+    """Sanity: our wrapper matches stdlib output exactly."""
+    sample = ALLAH_LIGATURE + DECOMPOSED_ALEF_HAMZA + "abc"
+    assert normalise_text(sample, form="NFC") == unicodedata.normalize("NFC", sample)
+    assert normalise_text(sample, form="NFKC") == unicodedata.normalize("NFKC", sample)


### PR DESCRIPTION
## Summary

Phase 7 of the Arabic PDF transcriber: emit Markdown and Word (.docx) from an ordered, role-classified `Region` stream produced by phase 6.

- **Markdown**: pure function `emit_markdown(regions, *, normalisation='NFC', apply_bidi=True) -> str`. GFM-compatible. Escape-safe. Byte-identical across runs.
- **Word**: `emit_docx(regions, output_path, *, normalisation='NFC', apply_bidi=True) -> None`. Built-in styles. `document.xml` byte-identical across runs (verified via zipfile read).
- **Bidi**: U+200F RLM prefix only when paragraph is Arabic-dominant *and* contains an LTR run. Idempotent.
- **Normalisation**: NFC default — preserves Arabic presentation forms (U+FDF2 ﷲ, lam-alef U+FEFB) per architect carry-over from phase 3 PR review. NFKC opt-in for search-friendly downstream use.
- **Lazy `python-docx`**: importing the `emit` package or `emit.markdown` does not pull `docx` into `sys.modules` (subprocess regression test).

### Per-role mapping

| Role | Markdown | docx |
|---|---|---|
| HEADING | `#` × level (1–6) | `Heading {level}` (1–9) |
| PARAGRAPH | escape-safe paragraph | `Normal` |
| LIST_ITEM | `- ` / `N. ` | `List Bullet` / `List Number` |
| TABLE | pipe-table | real Word table |
| FIGURE | `![alt](#)` | `Figure on page N` |
| CAPTION | italic / suppressed when paired with figure | italic run / suppressed when paired |
| HEADER_FOOTER | suppressed | suppressed |
| FAILURE_PLACEHOLDER | `<!-- … -->` | `Quote` style |
| UNKNOWN | paragraph fallback | `Normal` |

### Iter-1 consultation

- **codex** — `REQUEST_CHANGES` (HIGH): orphan grouped captions (caption with `group_id` but no matching figure) silently dropped. **Fixed**: suppression now keyed on `figure_ids ∩ caption_ids` set; orphan grouped captions render as normal italic captions. Two regression tests added (markdown + docx).
- **claude** — `APPROVE` (HIGH): no bugs.
- **gemini** — `SKIPPED`: API quota exhausted (10 retry attempts, same pattern as phases 4–6; architect-approved 2/3 acceptance).

Rebuttals: `codev/projects/1-arabic-pdf-transcriber-extract/1-phase_7_emitters_markdown_and_docx-iter1-rebuttals.md` (added in worktree, not on PR branch).

## Test plan

- [x] `make test` → 304 passed, 2 deselected
- [x] `make lint` → clean
- [x] `make audit` (license_audit) → OK
- [x] 103 phase-7 tests across 6 modules
  - `test_emit_normalise.py` — NFC/NFKC + presentation forms
  - `test_emit_md_escape.py` — leading-block + inline + table-cell escape
  - `test_emit_bidi.py` — Arabic-dominance + RLM idempotency
  - `test_emit_markdown.py` — per-role rendering, list grouping, table padding, figure-caption pairing, adversarial text, RLM injection, NFC/NFKC differential, byte-identical determinism, full-document snapshot, **orphan grouped caption regression**
  - `test_emit_docx.py` — per-role styles, Word table cells, suppression, network-purity socket mock, `document.xml` byte-identical, **orphan grouped caption regression**
  - `test_emit_lazy_import.py` — subprocess-isolated; `arabic_pdf_transcribe.emit*` does not load `docx`
- [x] Acceptance criteria from plan: byte-identical Markdown snapshot, byte-identical document.xml, no network I/O during emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)