### PR TITLE
[Spec 1][Phase 8] feat: CLI + pipeline orchestrator with full failure-mode coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B011"]
+"tests/*" = ["B011", "B008", "RUF001", "RUF002", "RUF003"]
 # An Arabic-PDF transcriber legitimately contains Arabic glyphs in
 # source; the ambiguous-character lints (RUF001 / RUF002) treat
 # Arabic digits and dashes as suspicious because they resemble
@@ -86,6 +86,7 @@ ignore = [
 # point of this codebase. Suppress where the glyph is intended.
 "src/arabic_pdf_transcribe/roles/*" = ["RUF001", "RUF002"]
 "src/arabic_pdf_transcribe/validate/*" = ["RUF001", "RUF002"]
+"src/arabic_pdf_transcribe/emit/*" = ["RUF001", "RUF002", "RUF003"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/src/arabic_pdf_transcribe/_logging.py
+++ b/src/arabic_pdf_transcribe/_logging.py
@@ -1,0 +1,130 @@
+"""Pipeline progress logging.
+
+The orchestrator emits one event per page (start, complete, failure)
+plus a final summary. The same event stream feeds three outputs:
+
+* **Default text mode** (``ProgressMode.TEXT``) — human-readable
+  ``"page X of N — extracted (native)"`` lines on stderr.
+* **Quiet mode** (``ProgressMode.QUIET``) — no output. The pipeline
+  still emits events; the logger swallows them.
+* **JSON mode** (``ProgressMode.JSON``) — one ``json.dumps`` line per
+  event on stderr. Schema:
+  ``{"page": int, "of": int, "event": str, "branch": str|None,
+  "reason": str|None, "ts": null}``. Timestamps are intentionally
+  absent so the JSON stream is byte-stable across runs (same input
+  → same stderr).
+
+The logger writes to ``stderr`` so primary output (Markdown to stdout
+or the docx file path) is never polluted by progress noise. It does
+not buffer: each event is flushed so a long-running run shows
+progress immediately.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import TextIO
+
+
+class ProgressMode(Enum):
+    TEXT = "text"
+    QUIET = "quiet"
+    JSON = "json"
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """One observable event in the pipeline's progress stream."""
+
+    page: int  # 1-based
+    of: int  # total page count
+    event: str  # "start" | "complete" | "failure" | "summary"
+    branch: str | None = None  # "native" | "ml" | None
+    reason: str | None = None  # populated on failure / summary
+
+
+class ProgressLogger:
+    """Render :class:`ProgressEvent`s to a text stream.
+
+    Construct with the chosen :class:`ProgressMode` and a stream
+    (defaults to ``sys.stderr``). Tests inject a ``StringIO`` to
+    capture output deterministically.
+    """
+
+    def __init__(
+        self,
+        mode: ProgressMode = ProgressMode.TEXT,
+        *,
+        stream: TextIO | None = None,
+    ) -> None:
+        self.mode = mode
+        self._stream: TextIO = stream if stream is not None else sys.stderr
+
+    def emit(self, event: ProgressEvent) -> None:
+        if self.mode is ProgressMode.QUIET:
+            return
+        if self.mode is ProgressMode.JSON:
+            self._stream.write(json.dumps(_event_to_dict(event), ensure_ascii=False) + "\n")
+        else:
+            self._stream.write(_format_text(event) + "\n")
+        self._stream.flush()
+
+    # Convenience helpers — keep the orchestrator one-liner-friendly.
+
+    def start(self, *, page: int, of: int, branch: str | None = None) -> None:
+        self.emit(ProgressEvent(page=page, of=of, event="start", branch=branch))
+
+    def complete(self, *, page: int, of: int, branch: str) -> None:
+        self.emit(ProgressEvent(page=page, of=of, event="complete", branch=branch))
+
+    def failure(self, *, page: int, of: int, reason: str, branch: str | None = None) -> None:
+        self.emit(
+            ProgressEvent(
+                page=page,
+                of=of,
+                event="failure",
+                branch=branch,
+                reason=reason,
+            )
+        )
+
+    def summary(self, *, of: int, ok_pages: int, failed_pages: int) -> None:
+        self.emit(
+            ProgressEvent(
+                page=of,
+                of=of,
+                event="summary",
+                reason=f"ok={ok_pages} failed={failed_pages}",
+            )
+        )
+
+
+def _event_to_dict(event: ProgressEvent) -> Mapping[str, object]:
+    return {
+        "page": event.page,
+        "of": event.of,
+        "event": event.event,
+        "branch": event.branch,
+        "reason": event.reason,
+    }
+
+
+def _format_text(event: ProgressEvent) -> str:
+    if event.event == "summary":
+        return f"summary: {event.of} pages, {event.reason}"
+    page_n = f"page {event.page} of {event.of}"
+    if event.event == "start":
+        branch = f" [{event.branch}]" if event.branch else ""
+        return f"{page_n} — start{branch}"
+    if event.event == "complete":
+        return f"{page_n} — complete ({event.branch})"
+    if event.event == "failure":
+        return f"{page_n} — FAILED: {event.reason}"
+    return f"{page_n} — {event.event}"  # pragma: no cover — defensive
+
+
+__all__ = ["ProgressEvent", "ProgressLogger", "ProgressMode"]

--- a/src/arabic_pdf_transcribe/cli.py
+++ b/src/arabic_pdf_transcribe/cli.py
@@ -1,28 +1,437 @@
-"""CLI entry point.
+"""CLI entry point for ``arabic-pdf-transcribe``.
 
-Phase 1 ships only the entry-point function so the ``arabic-pdf-transcribe``
-console script registered in ``pyproject.toml`` resolves cleanly during
-``pip install`` and during ``--help`` introspection. The real argument parser
-and pipeline wiring land in phase 8 (per the implementation plan).
+Command surface (per spec "Resolved Decisions" + plan phase 8):
 
-Calling ``main`` before phase 8 raises :class:`NotImplementedError` with a
-message that points at the spec / plan; this is intentional. We never want a
-half-wired CLI to silently produce empty or wrong output.
+::
+
+    arabic-pdf-transcribe FILE
+        [-o PATH] [--format {md,docx}]
+        [--pages RANGES]
+        [--strict] [--quiet] [--json-logs]
+        [--config PATH]
+        [--debug-json PATH]
+        [--max-workers N]
+        [--dpi N]
+
+Exit codes (mapped one-to-one to spec test scenarios 11-18):
+
+* ``0`` — success, including best-effort runs where some pages fail.
+* ``2`` — strict-mode abort, or every page failed in best-effort mode.
+* ``3`` — encrypted / password-protected PDF.
+* ``4`` — corrupted PDF, or ``--format`` and ``-o`` extension disagree.
+* ``5`` — ML model missing (download/cache miss).
+
+Argparse parses; :func:`validate_args` resolves format/extension
+conflicts and produces a :class:`ValidatedArgs` view; :func:`main`
+calls into :func:`pipeline.transcribe`, then dispatches to the
+emitters. The CLI never imports ``transformers`` / ``torch`` at the
+top level — the ML deps load only when the validator forces a page
+into the ML branch.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
+import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TextIO
 
-_PHASE_8_MESSAGE = (
-    "arabic-pdf-transcribe CLI is not implemented yet — it lands in plan phase 8 "
-    "(see codev/plans/1-arabic-pdf-transcriber-extract.md). "
-    "Phase 1 only ships the package skeleton and the license-audit harness."
+from arabic_pdf_transcribe._logging import ProgressLogger, ProgressMode
+from arabic_pdf_transcribe.errors import (
+    CorruptedPDFError,
+    EncryptedPDFError,
+    FormatExtensionMismatch,
+    ModelDownloadError,
+    OutOfMemoryDuringInference,
 )
+from arabic_pdf_transcribe.pipeline import TranscribeResult, transcribe
+from arabic_pdf_transcribe.validate.native_validator import ValidatorConfig
+
+OutputFormat = Literal["md", "docx"]
+
+EXIT_OK = 0
+EXIT_RUNTIME = 2
+EXIT_ENCRYPTED = 3
+EXIT_CORRUPTED_OR_FORMAT = 4
+EXIT_MODEL_MISSING = 5
+
+_MD_EXTS = frozenset({".md", ".markdown"})
+_DOCX_EXTS = frozenset({".docx"})
+
+
+# ---------------------------------------------------------------------------
+# Argparse + post-validation
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="arabic-pdf-transcribe",
+        description="Arabic-first PDF transcriber: extract → layout → ML fallback → MD/Word.",
+    )
+    parser.add_argument("input", type=Path, help="path to a PDF file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="output file path (defaults to stdout in Markdown)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("md", "docx"),
+        default=None,
+        help="output format; required when --output has no recognised extension",
+    )
+    parser.add_argument(
+        "--pages",
+        type=str,
+        default=None,
+        help="page ranges to process, e.g. 1-3,7,10-12 (1-based, inclusive)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="abort on the first per-page failure (default: best-effort)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress progress reporting on stderr",
+    )
+    parser.add_argument(
+        "--json-logs",
+        action="store_true",
+        help="emit progress as JSON lines on stderr (overrides text mode)",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="TOML config file for validator / layout / ocr / render overrides",
+    )
+    parser.add_argument(
+        "--debug-json",
+        type=Path,
+        default=None,
+        help="write a JSON sidecar with per-region confidences to PATH",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=str,
+        default="1",
+        help="per-page parallelism for the ML branch (1, N, or 'auto'; default 1)",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=None,
+        help="rasterisation DPI for the ML branch (default 200)",
+    )
+    return parser
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedArgs:
+    """Post-argparse, post-conflict-resolution view of CLI arguments."""
+
+    input: Path
+    output: Path | None
+    format: OutputFormat
+    pages: tuple[int, ...] | None  # 0-based, sorted, deduplicated
+    strict: bool
+    progress_mode: ProgressMode
+    config: Path | None
+    debug_json: Path | None
+    max_workers: int  # resolved from "auto" / int
+    dpi: int
+
+
+def validate_args(ns: argparse.Namespace) -> ValidatedArgs:
+    """Resolve format/extension conflicts and normalise inputs.
+
+    Raises :class:`FormatExtensionMismatch` (CLI exit 4) when
+    ``--format`` and the ``-o PATH`` extension disagree, per spec
+    test scenario 18, AND when ``--format docx`` is requested without
+    a ``-o PATH`` (a Word file cannot be written to stdout).
+    """
+    fmt = _resolve_format(ns.output, ns.format)
+    if fmt == "docx" and ns.output is None:
+        raise FormatExtensionMismatch(
+            "--format docx requires -o PATH (cannot write a Word file to stdout)"
+        )
+    pages = _parse_pages(ns.pages) if ns.pages else None
+    progress_mode = _resolve_progress_mode(quiet=ns.quiet, json_logs=ns.json_logs)
+    max_workers = _resolve_max_workers(ns.max_workers)
+    dpi = ns.dpi if ns.dpi is not None else 200
+    return ValidatedArgs(
+        input=ns.input,
+        output=ns.output,
+        format=fmt,
+        pages=pages,
+        strict=ns.strict,
+        progress_mode=progress_mode,
+        config=ns.config,
+        debug_json=ns.debug_json,
+        max_workers=max_workers,
+        dpi=dpi,
+    )
+
+
+def _resolve_format(output: Path | None, explicit: str | None) -> OutputFormat:
+    """Decide the output format from ``-o`` extension and ``--format``.
+
+    Rules (per spec):
+
+    * If both are present and disagree → :class:`FormatExtensionMismatch`.
+    * If ``-o`` has a recognised extension → extension wins.
+    * If ``-o`` is None or unknown extension → ``--format`` wins.
+    * If neither carries information → default to Markdown.
+    """
+    ext_format = _format_from_ext(output) if output is not None else None
+    if ext_format is not None and explicit is not None and ext_format != explicit:
+        raise FormatExtensionMismatch(
+            f"--format {explicit!r} disagrees with output extension {output!s} "
+            f"(extension implies {ext_format!r}); pass matching --format or change the path"
+        )
+    if ext_format is not None:
+        return ext_format
+    if explicit is not None:
+        return _cast_format(explicit)
+    return "md"
+
+
+def _format_from_ext(path: Path) -> OutputFormat | None:
+    suffix = path.suffix.lower()
+    if suffix in _MD_EXTS:
+        return "md"
+    if suffix in _DOCX_EXTS:
+        return "docx"
+    return None
+
+
+def _cast_format(value: str) -> OutputFormat:
+    if value not in ("md", "docx"):
+        raise ValueError(f"unsupported format: {value!r}")  # pragma: no cover — argparse-gated
+    return value  # type: ignore[return-value]
+
+
+def _parse_pages(spec: str) -> tuple[int, ...]:
+    """Parse ``"1-3,7,10-12"`` into 0-based, sorted, deduplicated indices.
+
+    Raises :class:`ValueError` on malformed spec; argparse surfaces
+    this to the user as a usage error (exit 2).
+    """
+    out: set[int] = set()
+    for chunk in spec.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "-" in chunk:
+            lo_s, hi_s = chunk.split("-", 1)
+            lo, hi = int(lo_s), int(hi_s)
+            if lo < 1 or hi < lo:
+                raise ValueError(f"invalid page range {chunk!r}")
+            for p in range(lo, hi + 1):
+                out.add(p - 1)
+        else:
+            n = int(chunk)
+            if n < 1:
+                raise ValueError(f"invalid page number {chunk!r}")
+            out.add(n - 1)
+    return tuple(sorted(out))
+
+
+def _resolve_progress_mode(*, quiet: bool, json_logs: bool) -> ProgressMode:
+    if quiet:
+        return ProgressMode.QUIET
+    if json_logs:
+        return ProgressMode.JSON
+    return ProgressMode.TEXT
+
+
+def _resolve_max_workers(value: str) -> int:
+    if value == "auto":
+        try:
+            import os
+
+            return min(os.cpu_count() or 1, 4)
+        except (AttributeError, OSError):  # pragma: no cover — defensive
+            return 1
+    try:
+        n = int(value)
+    except ValueError as exc:
+        raise ValueError(f"--max-workers must be an int or 'auto', got {value!r}") from exc
+    if n < 1:
+        raise ValueError(f"--max-workers must be >= 1, got {n}")
+    return n
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    raise NotImplementedError(_PHASE_8_MESSAGE)
+    parser = build_parser()
+    ns = parser.parse_args(argv)
+    try:
+        args = validate_args(ns)
+    except FormatExtensionMismatch as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_CORRUPTED_OR_FORMAT
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    logger = ProgressLogger(args.progress_mode, stream=sys.stderr)
+
+    validator_cfg = _load_validator_config(args.config)
+    layout_detector, ocr_transcriber = _maybe_build_ml_adapters()
+
+    def _progress(page_index: int, total: int, event: str) -> None:
+        page = page_index + 1
+        if event == "start":
+            logger.start(page=page, of=total)
+        elif event.startswith("complete:"):
+            branch = event.split(":", 1)[1]
+            logger.complete(page=page, of=total, branch=branch)
+        elif event.startswith("failure:"):
+            reason = event.split(":", 1)[1]
+            logger.failure(page=page, of=total, reason=reason)
+
+    try:
+        result = transcribe(
+            args.input,
+            layout_detector=layout_detector,
+            ocr_transcriber=ocr_transcriber,
+            validator_config=validator_cfg,
+            pages=args.pages,
+            strict=args.strict,
+            dpi=args.dpi,
+            max_workers=args.max_workers,
+            progress=_progress,
+        )
+    except FileNotFoundError as exc:
+        print(f"error: input file not found: {exc.filename or args.input}", file=sys.stderr)
+        return EXIT_CORRUPTED_OR_FORMAT
+    except EncryptedPDFError as exc:
+        print(f"error: encrypted PDF: {exc}", file=sys.stderr)
+        return EXIT_ENCRYPTED
+    except CorruptedPDFError as exc:
+        print(f"error: corrupted PDF: {exc}", file=sys.stderr)
+        return EXIT_CORRUPTED_OR_FORMAT
+    except ModelDownloadError as exc:
+        print(f"error: ML model unavailable: {exc}", file=sys.stderr)
+        return EXIT_MODEL_MISSING
+    except OutOfMemoryDuringInference as exc:
+        print(f"error: out-of-memory during inference: {exc}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    logger.summary(of=result.n_pages, ok_pages=result.ok_pages, failed_pages=result.failed_pages)
+
+    if result.all_failed and result.n_pages > 0:
+        print("error: every page failed; nothing to write", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    _write_output(args, result)
+
+    if args.debug_json is not None:
+        _write_debug_json(args.debug_json, result)
+
+    return EXIT_OK
 
 
-__all__ = ["main"]
+def _load_validator_config(config_path: Path | None) -> ValidatorConfig | None:
+    if config_path is None:
+        return None
+    return ValidatorConfig.from_toml(config_path)
+
+
+def _maybe_build_ml_adapters() -> tuple[object | None, object | None]:
+    """Return ``(layout_detector, ocr_transcriber)`` or ``(None, None)``.
+
+    The CLI only attempts to wire the ML adapters when their imports
+    succeed; the adapters themselves load their model lazily on the
+    first call. When the optional ``[ml]`` extra is not installed,
+    the CLI proceeds without ML support — pages that need the ML
+    branch will surface :class:`RuntimeError` from the orchestrator,
+    which we map to a per-page failure (or strict abort).
+    """
+    try:
+        from arabic_pdf_transcribe.layout.hf_detector import HFDiTLayoutDetector
+        from arabic_pdf_transcribe.ocr.hf_ocr import HFGotOCRTranscriber
+    except ImportError:
+        return None, None
+    try:
+        return HFDiTLayoutDetector(), HFGotOCRTranscriber()
+    except Exception:  # pragma: no cover — defensive; constructors are cheap
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+def _write_output(args: ValidatedArgs, result: TranscribeResult) -> None:
+    if args.format == "md":
+        from arabic_pdf_transcribe.emit.markdown import emit_markdown
+
+        markdown = emit_markdown(result.regions)
+        _write_text(args.output, markdown, sys.stdout)
+    else:
+        # docx + missing output path is rejected up-front in validate_args.
+        assert args.output is not None
+        from arabic_pdf_transcribe.emit.docx import emit_docx
+
+        emit_docx(result.regions, args.output)
+
+
+def _write_text(output: Path | None, text: str, stdout: TextIO) -> None:
+    if output is None:
+        stdout.write(text)
+        if not text.endswith("\n"):
+            stdout.write("\n")
+        stdout.flush()
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+
+
+def _write_debug_json(path: Path, result: TranscribeResult) -> None:
+    """Emit a per-region JSON sidecar with confidences."""
+    payload = {
+        "n_pages": result.n_pages,
+        "ok_pages": result.ok_pages,
+        "failed_pages": result.failed_pages,
+        "regions": [
+            {
+                "page_index": r.page_index,
+                "role": r.role.value,
+                "source": r.source.value,
+                "confidence": r.confidence,
+                "text_len": len(r.text),
+                "failure_reason": r.failure_reason,
+            }
+            for r in result.regions
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2))
+
+
+__all__ = [
+    "EXIT_CORRUPTED_OR_FORMAT",
+    "EXIT_ENCRYPTED",
+    "EXIT_MODEL_MISSING",
+    "EXIT_OK",
+    "EXIT_RUNTIME",
+    "ValidatedArgs",
+    "build_parser",
+    "main",
+    "validate_args",
+]

--- a/src/arabic_pdf_transcribe/errors.py
+++ b/src/arabic_pdf_transcribe/errors.py
@@ -58,10 +58,37 @@ class CorruptedPDFError(ArabicPdfTranscribeError):
     """
 
 
+class OutOfMemoryDuringInference(ArabicPdfTranscribeError):
+    """Raised when ML inference exhausts CPU or GPU memory.
+
+    The pipeline catches Python ``MemoryError`` and
+    ``torch.cuda.OutOfMemoryError`` at the per-page boundary and
+    re-raises this typed wrapper so callers can decide whether to
+    treat the failure as a per-page placeholder (default best-effort
+    mode) or to abort the run (``--strict``).
+
+    The message includes a hint pointing at the lowest-cost mitigation
+    (reduce ``--render.dpi`` or use the smaller fallback model) per
+    the spec's "OOM during ML inference" failure mode.
+    """
+
+
+class FormatExtensionMismatch(ArabicPdfTranscribeError):
+    """Raised when ``--format`` and the output extension disagree.
+
+    Mapped to CLI exit code 4 (per spec test scenario 18). Surfaced
+    by :func:`arabic_pdf_transcribe.cli.validate_args` before any
+    extraction or rasterisation work happens, so the user sees the
+    error immediately and no temp files are created.
+    """
+
+
 __all__ = [
     "ArabicPdfTranscribeError",
     "CorruptedPDFError",
     "EncryptedPDFError",
+    "FormatExtensionMismatch",
     "ModelDownloadError",
     "OCRTranscriptionError",
+    "OutOfMemoryDuringInference",
 ]

--- a/src/arabic_pdf_transcribe/pipeline.py
+++ b/src/arabic_pdf_transcribe/pipeline.py
@@ -1,0 +1,480 @@
+"""End-to-end pipeline orchestrator.
+
+Wires every prior phase into one ``transcribe(pdf_path, ...)`` entry
+point:
+
+1. **Open** the PDF (encrypted / corrupted PDFs raise typed errors).
+2. **Per page**:
+   a. **Native extract** + per-page **validate**.
+   b. If validation accepts → take the native regions.
+   c. Else → **rasterise** → **layout-detect** → **per-region OCR**.
+   d. **Reorder** + **classify roles**.
+   e. On any caught failure, synthesise a single
+      :data:`RegionRole.FAILURE_PLACEHOLDER` region for the page so
+      the emitter still produces output for that page slot.
+3. **Yield** a :class:`PageOutcome` per page; collect into
+   :class:`TranscribeResult`.
+
+The orchestrator depends on ``LayoutDetector`` and ``OCRTranscriber``
+*Protocols* — production wiring uses the HF adapters, tests inject
+stubs. The validator, the rasteriser, the reorderer, the role
+classifier, and the emitters are pluggable too (callable kwargs with
+sensible defaults).
+
+A process-scoped :class:`tempfile.TemporaryDirectory` is created on
+entry and removed on exit (success or failure). Page rasterisation
+keeps images in memory by default; the temp dir is reserved for
+adapters that need a path-shaped artefact.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from arabic_pdf_transcribe.errors import (
+    ArabicPdfTranscribeError,
+    OutOfMemoryDuringInference,
+)
+from arabic_pdf_transcribe.extract.native import NativePage, extract_native
+from arabic_pdf_transcribe.regions import BBox, Region, RegionRole, RegionSource
+from arabic_pdf_transcribe.roles.classify import ClassifyConfig, classify_page
+from arabic_pdf_transcribe.validate.native_validator import (
+    ValidationResult,
+    ValidatorConfig,
+    validate_page,
+)
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
+
+    from arabic_pdf_transcribe.layout import LayoutDetector
+    from arabic_pdf_transcribe.ocr import OCRTranscriber
+
+# Reorder is a small pure helper — re-exported through the package.
+from arabic_pdf_transcribe.order.reorder import reorder as _reorder_default
+
+DEFAULT_DPI = 200
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PageOutcome:
+    """Per-page record: which branch ran and what came out."""
+
+    page_index: int
+    branch: str  # "native" | "ml" | "failed"
+    regions: tuple[Region, ...]
+    validation: ValidationResult | None = None
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TranscribeResult:
+    """Aggregate result returned by :func:`transcribe`."""
+
+    pages: tuple[PageOutcome, ...]
+    regions: tuple[Region, ...]  # flattened across pages, in reading order
+
+    @property
+    def n_pages(self) -> int:
+        return len(self.pages)
+
+    @property
+    def ok_pages(self) -> int:
+        return sum(1 for p in self.pages if p.branch != "failed")
+
+    @property
+    def failed_pages(self) -> int:
+        return sum(1 for p in self.pages if p.branch == "failed")
+
+    @property
+    def all_failed(self) -> bool:
+        return self.n_pages > 0 and self.ok_pages == 0
+
+
+# ---------------------------------------------------------------------------
+# Page-rendering helper (lazy pypdfium2 + Pillow imports)
+# ---------------------------------------------------------------------------
+
+
+def _rasterise_page_at_index(pdf_path: Path, page_index: int, *, dpi: int) -> PILImage:
+    """Open ``pdf_path``, rasterise ``page_index`` at ``dpi``, return image.
+
+    The render uses :mod:`arabic_pdf_transcribe.layout._rasterise` which
+    in turn pulls Pillow lazily (gated behind the ``[ml]`` extra). The
+    document is closed deterministically on exit.
+    """
+    from arabic_pdf_transcribe.layout._rasterise import rasterise_page
+    from arabic_pdf_transcribe.pdf._pypdfium2_loader import open_pdf
+
+    with open_pdf(pdf_path) as document:
+        page = document[page_index]
+        try:
+            return rasterise_page(page, dpi=dpi)
+        finally:
+            page.close()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+ProgressCallback = Callable[[int, int, str], None]
+"""``(page_index, total_pages, event)`` — best-effort, fire-and-forget.
+
+The orchestrator calls this for ``"start"``, ``"complete"``, and
+``"failure"`` events on each page. Callbacks must not raise; the
+orchestrator does not catch.
+"""
+
+
+def transcribe(
+    pdf_path: Path | str,
+    *,
+    layout_detector: LayoutDetector | None = None,
+    ocr_transcriber: OCRTranscriber | None = None,
+    validator: Callable[[NativePage, ValidatorConfig], ValidationResult] | None = None,
+    validator_config: ValidatorConfig | None = None,
+    classify_config: ClassifyConfig | None = None,
+    reorder_fn: Callable[..., list[Region]] | None = None,
+    rtl: bool = True,
+    dpi: int = DEFAULT_DPI,
+    pages: Iterable[int] | None = None,
+    strict: bool = False,
+    max_workers: int = 1,
+    progress: ProgressCallback | None = None,
+) -> TranscribeResult:
+    """Transcribe ``pdf_path`` and return a :class:`TranscribeResult`.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to a local PDF. Encrypted / corrupted PDFs surface as
+        :class:`EncryptedPDFError` / :class:`CorruptedPDFError` from
+        the loader; the caller maps these to CLI exit codes.
+    layout_detector:
+        Optional :class:`LayoutDetector` for the ML branch. When
+        ``None`` and the ML branch is needed, the orchestrator raises
+        :class:`RuntimeError`. The CLI wires the production HF
+        adapter; tests inject a stub.
+    ocr_transcriber:
+        Optional :class:`OCRTranscriber` — same pattern as
+        ``layout_detector``.
+    validator:
+        Pluggable per-page validator. Defaults to
+        :func:`validate_page`.
+    validator_config:
+        Optional :class:`ValidatorConfig` override.
+    classify_config:
+        Optional :class:`ClassifyConfig` override.
+    reorder_fn:
+        Pluggable reorderer. Defaults to
+        :func:`arabic_pdf_transcribe.order.reorder.reorder`.
+    rtl:
+        Pass through to ``reorder_fn`` and ``classify_page``. Default
+        ``True`` for Arabic-first usage.
+    dpi:
+        Rasterisation DPI for the ML branch. Default 200.
+    pages:
+        Optional iterable of *0-based* page indices to process; pages
+        outside the set are skipped before any per-page work — the
+        loader is opened once for the page count, then native
+        extraction, validation, and the ML branch run only for
+        selected pages.
+    strict:
+        When ``True``, the first per-page failure aborts the run by
+        re-raising the underlying exception. When ``False`` (default,
+        best-effort mode), failures synthesise a placeholder region
+        and the pipeline continues.
+    max_workers:
+        Reserved for future per-page parallelism on the ML branch
+        (default ``1``, sequential). v1 keeps the loop sequential to
+        bound peak RSS — the parameter is plumbed through so the
+        CLI surface is stable; phase 9 will enable parallel ML
+        runs after benchmarking.
+    progress:
+        Optional ``(page_index, total_pages, event)`` callback for
+        progress reporting.
+    """
+    pdf_path = Path(pdf_path)
+    if max_workers < 1:
+        raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+    selected = _normalise_page_filter(pages)
+    actual_validator = validator or _default_validator
+    cfg = validator_config or ValidatorConfig()
+    reorder_call = reorder_fn or _reorder_default
+    classify_cfg = classify_config or ClassifyConfig(rtl=rtl)
+
+    pages_out: list[PageOutcome] = []
+    flat_regions: list[Region] = []
+
+    with _process_temp_dir() as _tmp:
+        # Cheap pre-pass: open the document just to get the total
+        # page count. The loader translates encrypted/corrupted
+        # errors at the boundary, so those exit codes fire here
+        # before any extraction work.
+        total = _count_pages(pdf_path)
+        for native_page in _iter_selected_native_pages(pdf_path, selected):
+            outcome = _process_page(
+                pdf_path=pdf_path,
+                native_page=native_page,
+                total=total,
+                validator=actual_validator,
+                validator_config=cfg,
+                layout_detector=layout_detector,
+                ocr_transcriber=ocr_transcriber,
+                reorder_call=reorder_call,
+                classify_cfg=classify_cfg,
+                rtl=rtl,
+                dpi=dpi,
+                strict=strict,
+                progress=progress,
+            )
+            pages_out.append(outcome)
+            flat_regions.extend(outcome.regions)
+
+    return TranscribeResult(pages=tuple(pages_out), regions=tuple(flat_regions))
+
+
+def _count_pages(pdf_path: Path) -> int:
+    """Open the document once just to read its page count."""
+    from arabic_pdf_transcribe.pdf._pypdfium2_loader import open_pdf
+
+    with open_pdf(pdf_path) as document:
+        return len(document)
+
+
+def _iter_selected_native_pages(pdf_path: Path, selected: set[int] | None) -> Iterator[NativePage]:
+    """Yield only native pages whose 0-based index is in ``selected``.
+
+    ``extract_native`` is iterator-shaped; we read it lazily and skip
+    the body for non-selected pages. The PDF is opened once.
+    """
+    for native_page in extract_native(pdf_path):
+        if selected is not None and native_page.page_index not in selected:
+            continue
+        yield native_page
+
+
+# ---------------------------------------------------------------------------
+# Per-page processing
+# ---------------------------------------------------------------------------
+
+
+def _process_page(
+    *,
+    pdf_path: Path,
+    native_page: NativePage,
+    total: int,
+    validator: Callable[[NativePage, ValidatorConfig], ValidationResult],
+    validator_config: ValidatorConfig,
+    layout_detector: LayoutDetector | None,
+    ocr_transcriber: OCRTranscriber | None,
+    reorder_call: Callable[..., list[Region]],
+    classify_cfg: ClassifyConfig,
+    rtl: bool,
+    dpi: int,
+    strict: bool,
+    progress: ProgressCallback | None,
+) -> PageOutcome:
+    page_index = native_page.page_index
+    _emit_progress(progress, page_index, total, "start")
+    try:
+        result = validator(native_page, validator_config)
+        if result.accept:
+            regions = _post_process_regions(
+                native_page.regions,
+                page_width=native_page.page_width,
+                page_height=native_page.page_height,
+                reorder_call=reorder_call,
+                classify_cfg=classify_cfg,
+                rtl=rtl,
+            )
+            _emit_progress(progress, page_index, total, "complete:native")
+            return PageOutcome(
+                page_index=page_index,
+                branch="native",
+                regions=tuple(regions),
+                validation=result,
+            )
+        # ML fallback.
+        regions = _run_ml_branch(
+            pdf_path=pdf_path,
+            native_page=native_page,
+            layout_detector=layout_detector,
+            ocr_transcriber=ocr_transcriber,
+            reorder_call=reorder_call,
+            classify_cfg=classify_cfg,
+            rtl=rtl,
+            dpi=dpi,
+        )
+        _emit_progress(progress, page_index, total, "complete:ml")
+        return PageOutcome(
+            page_index=page_index,
+            branch="ml",
+            regions=tuple(regions),
+            validation=result,
+        )
+    except MemoryError as exc:
+        reason = "out_of_memory"
+        if strict:
+            raise OutOfMemoryDuringInference(
+                f"page {page_index + 1}: {exc}; reduce --max-workers or rasterisation DPI"
+            ) from exc
+        _emit_progress(progress, page_index, total, f"failure:{reason}")
+        return _failure_outcome(page_index, native_page, reason)
+    except ArabicPdfTranscribeError as exc:
+        reason = type(exc).__name__
+        if strict:
+            raise
+        _emit_progress(progress, page_index, total, f"failure:{reason}")
+        return _failure_outcome(page_index, native_page, reason)
+    except RuntimeError as exc:
+        # ``torch.cuda.OutOfMemoryError`` subclasses RuntimeError —
+        # detect by class name + module so we don't have to import
+        # torch (it may not be installed). Other RuntimeErrors are
+        # treated as generic per-page failures below.
+        if _is_cuda_oom(exc):
+            if strict:
+                raise OutOfMemoryDuringInference(
+                    f"page {page_index + 1}: CUDA OOM: {exc}; "
+                    f"reduce --max-workers or rasterisation DPI"
+                ) from exc
+            _emit_progress(progress, page_index, total, "failure:cuda_out_of_memory")
+            return _failure_outcome(page_index, native_page, "cuda_out_of_memory")
+        reason = f"{type(exc).__name__}:{exc}"
+        if strict:
+            raise
+        _emit_progress(progress, page_index, total, f"failure:{reason}")
+        return _failure_outcome(page_index, native_page, reason)
+    except Exception as exc:
+        reason = f"{type(exc).__name__}:{exc}"
+        if strict:
+            raise
+        _emit_progress(progress, page_index, total, f"failure:{reason}")
+        return _failure_outcome(page_index, native_page, reason)
+
+
+def _is_cuda_oom(exc: BaseException) -> bool:
+    cls = type(exc)
+    name = cls.__name__
+    module = (cls.__module__ or "").split(".", 1)[0]
+    return name == "OutOfMemoryError" and module == "torch"
+
+
+def _run_ml_branch(
+    *,
+    pdf_path: Path,
+    native_page: NativePage,
+    layout_detector: LayoutDetector | None,
+    ocr_transcriber: OCRTranscriber | None,
+    reorder_call: Callable[..., list[Region]],
+    classify_cfg: ClassifyConfig,
+    rtl: bool,
+    dpi: int,
+) -> list[Region]:
+    if layout_detector is None or ocr_transcriber is None:
+        raise RuntimeError(
+            "ML branch needed for page "
+            f"{native_page.page_index + 1} but no layout_detector / ocr_transcriber wired"
+        )
+    page_image = _rasterise_page_at_index(pdf_path, native_page.page_index, dpi=dpi)
+    detected = list(layout_detector.detect(page_image, native_page.page_index))
+    transcribed: list[Region] = []
+    for region in detected:
+        if region.role is RegionRole.FIGURE:
+            transcribed.append(region)
+            continue
+        transcribed.append(ocr_transcriber.transcribe(region, page_image))
+    return _post_process_regions(
+        transcribed,
+        page_width=native_page.page_width,
+        page_height=native_page.page_height,
+        reorder_call=reorder_call,
+        classify_cfg=classify_cfg,
+        rtl=rtl,
+    )
+
+
+def _post_process_regions(
+    regions: Sequence[Region],
+    *,
+    page_width: float,
+    page_height: float,
+    reorder_call: Callable[..., list[Region]],
+    classify_cfg: ClassifyConfig,
+    rtl: bool,
+) -> list[Region]:
+    """Run reorder + role classification."""
+    if not regions:
+        return []
+    reordered = reorder_call(regions, page_width, page_height, rtl=rtl)
+    return classify_page(reordered, page_width, page_height, config=classify_cfg)
+
+
+def _failure_outcome(page_index: int, native_page: NativePage, reason: str) -> PageOutcome:
+    """Synthesise a single-region failure placeholder for the page."""
+    placeholder = Region.as_failure_placeholder(
+        reason=reason,
+        page_index=page_index,
+        bbox=BBox(0.0, 0.0, native_page.page_width, native_page.page_height),
+        source=RegionSource.NATIVE,
+    )
+    return PageOutcome(
+        page_index=page_index,
+        branch="failed",
+        regions=(placeholder,),
+        failure_reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_validator(page: NativePage, config: ValidatorConfig) -> ValidationResult:
+    return validate_page(page, config=config)
+
+
+def _normalise_page_filter(pages: Iterable[int] | None) -> set[int] | None:
+    if pages is None:
+        return None
+    return {int(p) for p in pages}
+
+
+def _emit_progress(
+    progress: ProgressCallback | None,
+    page_index: int,
+    total: int,
+    event: str,
+) -> None:
+    if progress is None:
+        return
+    progress(page_index, total, event)
+
+
+@contextmanager
+def _process_temp_dir() -> Iterator[Path]:
+    """Process-scoped temp dir; removed on context exit (always)."""
+    with tempfile.TemporaryDirectory(prefix="arabic-pdf-transcribe-") as tmp:
+        yield Path(tmp)
+
+
+__all__ = [
+    "DEFAULT_DPI",
+    "PageOutcome",
+    "ProgressCallback",
+    "TranscribeResult",
+    "transcribe",
+]

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,213 @@
+"""Phase-8 CLI argument parsing + format-selection tests.
+
+Covers spec test scenario 18 (format-extension mismatch → exit 4)
+and the resolved-decisions rules: extension wins when present,
+``--format`` wins otherwise, stdout defaults to Markdown.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from arabic_pdf_transcribe._logging import ProgressMode
+from arabic_pdf_transcribe.cli import (
+    EXIT_CORRUPTED_OR_FORMAT,
+    EXIT_OK,
+    EXIT_RUNTIME,
+    build_parser,
+    main,
+    validate_args,
+)
+from arabic_pdf_transcribe.errors import FormatExtensionMismatch
+
+
+def _parse(*argv: str):
+    return build_parser().parse_args(list(argv))
+
+
+# ---------------------------------------------------------------------------
+# Format selection
+# ---------------------------------------------------------------------------
+
+
+def test_format_default_is_markdown_to_stdout(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf)))
+    assert args.format == "md"
+    assert args.output is None
+
+
+def test_md_extension_drives_format(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "-o", str(tmp_path / "out.md")))
+    assert args.format == "md"
+
+
+def test_markdown_extension_drives_format(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "-o", str(tmp_path / "out.markdown")))
+    assert args.format == "md"
+
+
+def test_docx_extension_drives_format(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "-o", str(tmp_path / "out.docx")))
+    assert args.format == "docx"
+
+
+def test_explicit_format_wins_when_extension_unknown(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "-o", str(tmp_path / "out.txt"), "--format", "md"))
+    assert args.format == "md"
+
+
+def test_format_extension_mismatch_raises(tmp_path: Path) -> None:
+    """Spec scenario 18: --format docx -o out.md → exit 4."""
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    with pytest.raises(FormatExtensionMismatch):
+        validate_args(_parse(str(pdf), "-o", str(tmp_path / "out.md"), "--format", "docx"))
+
+
+def test_format_extension_mismatch_main_returns_exit_4(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    rc = main([str(pdf), "-o", str(tmp_path / "out.md"), "--format", "docx"])
+    assert rc == EXIT_CORRUPTED_OR_FORMAT
+
+
+# ---------------------------------------------------------------------------
+# --pages parsing
+# ---------------------------------------------------------------------------
+
+
+def test_pages_single(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--pages", "3"))
+    assert args.pages == (2,)  # 0-based
+
+
+def test_pages_range_and_singletons(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--pages", "1-3,7,10-12"))
+    assert args.pages == (0, 1, 2, 6, 9, 10, 11)
+
+
+def test_pages_dedupes_and_sorts(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--pages", "5,1,3,1-2"))
+    assert args.pages == (0, 1, 2, 4)
+
+
+def test_pages_invalid_range_returns_exit_2(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    rc = main([str(pdf), "--pages", "5-3"])
+    assert rc == EXIT_RUNTIME
+
+
+def test_pages_zero_returns_exit_2(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    rc = main([str(pdf), "--pages", "0"])
+    assert rc == EXIT_RUNTIME
+
+
+# ---------------------------------------------------------------------------
+# Progress mode
+# ---------------------------------------------------------------------------
+
+
+def test_default_progress_mode_is_text(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf)))
+    assert args.progress_mode is ProgressMode.TEXT
+
+
+def test_quiet_overrides_text(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--quiet"))
+    assert args.progress_mode is ProgressMode.QUIET
+
+
+def test_json_logs_selects_json_mode(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--json-logs"))
+    assert args.progress_mode is ProgressMode.JSON
+
+
+def test_quiet_takes_precedence_over_json_logs(tmp_path: Path) -> None:
+    """--quiet wins; useful for CI piping where stderr is discarded anyway."""
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--quiet", "--json-logs"))
+    assert args.progress_mode is ProgressMode.QUIET
+
+
+# ---------------------------------------------------------------------------
+# --max-workers
+# ---------------------------------------------------------------------------
+
+
+def test_max_workers_default_is_one(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf)))
+    assert args.max_workers == 1
+
+
+def test_max_workers_int(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--max-workers", "4"))
+    assert args.max_workers == 4
+
+
+def test_max_workers_auto_clamps_to_4(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    args = validate_args(_parse(str(pdf), "--max-workers", "auto"))
+    assert 1 <= args.max_workers <= 4
+
+
+def test_max_workers_invalid_returns_exit_2(tmp_path: Path) -> None:
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"")
+    rc = main([str(pdf), "--max-workers", "0"])
+    assert rc == EXIT_RUNTIME
+
+
+# ---------------------------------------------------------------------------
+# Smoke: --help short-circuits
+# ---------------------------------------------------------------------------
+
+
+def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+    assert exc_info.value.code == EXIT_OK
+    captured = capsys.readouterr()
+    assert "arabic-pdf-transcribe" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Missing input file → exit 4
+# ---------------------------------------------------------------------------
+
+
+def test_missing_input_returns_exit_4(tmp_path: Path) -> None:
+    rc = main([str(tmp_path / "does-not-exist.pdf")])
+    assert rc == EXIT_CORRUPTED_OR_FORMAT

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,208 @@
+"""Phase-8 end-to-end CLI integration tests.
+
+Exercises ``arabic_pdf_transcribe.cli.main`` against the in-tree
+fixtures with the validator forced into ``accept`` (native branch
+only, no ML model load). The tests assert exit codes, output file
+shape, and progress-stream content.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from arabic_pdf_transcribe.cli import (
+    EXIT_CORRUPTED_OR_FORMAT,
+    EXIT_ENCRYPTED,
+    EXIT_OK,
+    main,
+)
+from arabic_pdf_transcribe.errors import EncryptedPDFError
+from arabic_pdf_transcribe.validate.native_validator import (
+    ValidationResult,
+    ValidatorConfig,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "pdfs"
+CLEAN = FIXTURES / "digital-clean" / "lorem-ar-real.pdf"
+
+
+def _force_native_accept() -> object:
+    def _accept(page: object, config: ValidatorConfig) -> ValidationResult:
+        return ValidationResult(accept=True, signals={}, reasons=())
+
+    return _accept
+
+
+def _patched_main(argv: list[str]) -> int:
+    """Run ``main`` with the validator forced to accept every page.
+
+    Patching at the pipeline boundary keeps the CLI surface unchanged
+    — the test models a clean digital input.
+    """
+    accept = _force_native_accept()
+    real_transcribe = __import__(
+        "arabic_pdf_transcribe.pipeline", fromlist=["transcribe"]
+    ).transcribe
+
+    def _wrapped(*args: object, **kwargs: object) -> object:
+        kwargs["validator"] = accept  # type: ignore[index]
+        return real_transcribe(*args, **kwargs)
+
+    with patch("arabic_pdf_transcribe.cli.transcribe", new=_wrapped):
+        return main(argv)
+
+
+# ---------------------------------------------------------------------------
+# Exit code 0 — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_md_output_to_file_returns_zero(tmp_path: Path) -> None:
+    out = tmp_path / "out.md"
+    rc = _patched_main([str(CLEAN), "-o", str(out), "--quiet"])
+    assert rc == EXIT_OK
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_md_output_to_stdout_returns_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = _patched_main([str(CLEAN), "--quiet"])
+    captured = capsys.readouterr()
+    assert rc == EXIT_OK
+    assert len(captured.out) > 0
+
+
+def test_docx_output_to_file_returns_zero(tmp_path: Path) -> None:
+    out = tmp_path / "out.docx"
+    rc = _patched_main([str(CLEAN), "-o", str(out), "--quiet"])
+    assert rc == EXIT_OK
+    assert out.exists()
+    # Word files are zip archives starting with PK\x03\x04.
+    head = out.read_bytes()[:4]
+    assert head == b"PK\x03\x04"
+
+
+# ---------------------------------------------------------------------------
+# --debug-json sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_debug_json_sidecar_written(tmp_path: Path) -> None:
+    out = tmp_path / "out.md"
+    sidecar = tmp_path / "debug.json"
+    rc = _patched_main(
+        [
+            str(CLEAN),
+            "-o",
+            str(out),
+            "--debug-json",
+            str(sidecar),
+            "--quiet",
+        ]
+    )
+    assert rc == EXIT_OK
+    assert sidecar.exists()
+    import json
+
+    data = json.loads(sidecar.read_text())
+    assert "regions" in data
+    assert "n_pages" in data
+    assert data["n_pages"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Progress streams
+# ---------------------------------------------------------------------------
+
+
+def test_text_progress_writes_to_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    out = tmp_path / "out.md"
+    _patched_main([str(CLEAN), "-o", str(out)])
+    captured = capsys.readouterr()
+    assert "page" in captured.err.lower() or "summary" in captured.err.lower()
+
+
+def test_quiet_suppresses_progress(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    out = tmp_path / "out.md"
+    _patched_main([str(CLEAN), "-o", str(out), "--quiet"])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_json_logs_emits_json_lines(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    out = tmp_path / "out.md"
+    _patched_main([str(CLEAN), "-o", str(out), "--json-logs"])
+    captured = capsys.readouterr()
+    import json
+
+    lines = [line for line in captured.err.splitlines() if line.strip()]
+    assert lines
+    for line in lines:
+        json.loads(line)  # raises on invalid JSON
+
+
+# ---------------------------------------------------------------------------
+# Encrypted / corrupted handling — exit 3 / 4
+# ---------------------------------------------------------------------------
+
+
+def test_encrypted_pdf_returns_exit_3(tmp_path: Path) -> None:
+    """Spec scenario 12. Patches the loader to raise EncryptedPDFError."""
+    out = tmp_path / "out.md"
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise EncryptedPDFError("encrypted")
+
+    with patch("arabic_pdf_transcribe.cli.transcribe", new=_boom):
+        rc = main([str(CLEAN), "-o", str(out), "--quiet"])
+    assert rc == EXIT_ENCRYPTED
+
+
+def test_corrupted_pdf_returns_exit_4(tmp_path: Path) -> None:
+    """Spec scenario 13: corrupted PDF → exit 4."""
+    bogus = tmp_path / "bogus.pdf"
+    bogus.write_bytes(b"not a pdf at all")
+    out = tmp_path / "out.md"
+    rc = main([str(bogus), "-o", str(out), "--quiet"])
+    assert rc == EXIT_CORRUPTED_OR_FORMAT
+
+
+# ---------------------------------------------------------------------------
+# --pages filter on a real PDF
+# ---------------------------------------------------------------------------
+
+
+def test_pages_filter_limits_output(tmp_path: Path) -> None:
+    out = tmp_path / "out.md"
+    rc = _patched_main([str(CLEAN), "-o", str(out), "--pages", "1", "--quiet"])
+    assert rc == EXIT_OK
+    assert out.exists()
+
+
+def test_model_download_error_returns_exit_5(tmp_path: Path) -> None:
+    """Spec: ModelDownloadError → exit 5 with hint."""
+    from arabic_pdf_transcribe.cli import EXIT_MODEL_MISSING
+    from arabic_pdf_transcribe.errors import ModelDownloadError
+
+    out = tmp_path / "out.md"
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise ModelDownloadError(
+            "model X@rev Y not in cache; run huggingface-cli download X --revision Y"
+        )
+
+    with patch("arabic_pdf_transcribe.cli.transcribe", new=_boom):
+        rc = main([str(CLEAN), "-o", str(out), "--quiet"])
+    assert rc == EXIT_MODEL_MISSING
+
+
+def test_format_docx_without_output_returns_exit_4(tmp_path: Path) -> None:
+    """Codex feedback: ``--format docx`` to stdout is rejected up-front
+    in validate_args, not later in the output writer."""
+    rc = main([str(CLEAN), "--format", "docx", "--quiet"])
+    assert rc == EXIT_CORRUPTED_OR_FORMAT

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,97 @@
+"""Phase-8 progress logger tests.
+
+The logger is a small adapter from :class:`ProgressEvent`s to a text
+stream in one of three modes (text / quiet / JSON). All tests use a
+captured stream so we never write to real stderr.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from arabic_pdf_transcribe._logging import (
+    ProgressEvent,
+    ProgressLogger,
+    ProgressMode,
+)
+
+
+def _logger(mode: ProgressMode) -> tuple[ProgressLogger, io.StringIO]:
+    buf = io.StringIO()
+    return ProgressLogger(mode, stream=buf), buf
+
+
+def test_text_mode_emits_human_readable_lines() -> None:
+    log, buf = _logger(ProgressMode.TEXT)
+    log.start(page=1, of=3, branch="native")
+    log.complete(page=1, of=3, branch="native")
+    out = buf.getvalue()
+    assert "page 1 of 3" in out
+    assert "start" in out
+    assert "complete (native)" in out
+
+
+def test_quiet_mode_emits_nothing() -> None:
+    log, buf = _logger(ProgressMode.QUIET)
+    log.start(page=1, of=3)
+    log.complete(page=1, of=3, branch="ml")
+    log.failure(page=1, of=3, reason="oom")
+    log.summary(of=3, ok_pages=2, failed_pages=1)
+    assert buf.getvalue() == ""
+
+
+def test_json_mode_emits_one_object_per_line() -> None:
+    log, buf = _logger(ProgressMode.JSON)
+    log.start(page=2, of=5, branch="native")
+    log.failure(page=2, of=5, reason="ocr_failed")
+    lines = [line for line in buf.getvalue().splitlines() if line]
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first == {"page": 2, "of": 5, "event": "start", "branch": "native", "reason": None}
+    second = json.loads(lines[1])
+    assert second["event"] == "failure"
+    assert second["reason"] == "ocr_failed"
+
+
+def test_json_mode_byte_stable_across_runs() -> None:
+    """Acceptance: JSON stream has no timestamps; same input → same bytes."""
+    a_log, a_buf = _logger(ProgressMode.JSON)
+    b_log, b_buf = _logger(ProgressMode.JSON)
+    for log in (a_log, b_log):
+        log.start(page=1, of=2, branch="native")
+        log.complete(page=1, of=2, branch="native")
+        log.summary(of=2, ok_pages=2, failed_pages=0)
+    assert a_buf.getvalue() == b_buf.getvalue()
+
+
+def test_summary_event_text_format() -> None:
+    log, buf = _logger(ProgressMode.TEXT)
+    log.summary(of=10, ok_pages=8, failed_pages=2)
+    out = buf.getvalue().strip()
+    assert "summary" in out
+    assert "10 pages" in out
+    assert "ok=8" in out
+    assert "failed=2" in out
+
+
+def test_failure_text_includes_reason() -> None:
+    log, buf = _logger(ProgressMode.TEXT)
+    log.failure(page=4, of=10, reason="OCRTranscriptionError")
+    out = buf.getvalue().strip()
+    assert "page 4 of 10" in out
+    assert "FAILED" in out
+    assert "OCRTranscriptionError" in out
+
+
+def test_event_dataclass_is_immutable() -> None:
+    event = ProgressEvent(page=1, of=2, event="start")
+    import dataclasses
+
+    assert dataclasses.is_dataclass(event)
+    # frozen=True means setattr raises
+    try:
+        event.page = 99  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("ProgressEvent should be frozen")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,391 @@
+"""Phase-8 pipeline orchestrator tests.
+
+Stub :class:`LayoutDetector` and :class:`OCRTranscriber` are injected so
+the ML branch runs without loading any model. Real PDFs come from the
+in-tree fixtures in ``tests/fixtures/pdfs/``.
+
+Coverage targets (per plan acceptance criteria):
+
+* Best-effort default vs ``strict``.
+* All-failed pages → ``TranscribeResult.all_failed``.
+* Failure-region synthesis (one ``RegionRole.FAILURE_PLACEHOLDER`` per
+  failed page).
+* Temp-dir cleanup on success and failure.
+* ``pages`` filter skips work for pages outside the set.
+"""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+
+import pytest
+
+from arabic_pdf_transcribe.errors import OCRTranscriptionError
+from arabic_pdf_transcribe.pipeline import TranscribeResult, transcribe
+from arabic_pdf_transcribe.regions import (
+    BBox,
+    Region,
+    RegionRole,
+    RegionSource,
+)
+from arabic_pdf_transcribe.validate.native_validator import (
+    ValidationResult,
+    ValidatorConfig,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "pdfs"
+CLEAN = FIXTURES / "digital-clean" / "lorem-ar-real.pdf"
+BROKEN = FIXTURES / "digital-broken" / "mojibake.pdf"
+SCAN = FIXTURES / "image-scan" / "scan-ar-1col.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Stub adapters
+# ---------------------------------------------------------------------------
+
+
+class _StubLayoutDetector:
+    """One paragraph region per page. No model load."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def detect(self, page_image: object, page_index: int) -> list[Region]:
+        self.calls += 1
+        return [
+            Region(
+                page_index=page_index,
+                bbox=BBox(0.0, 0.0, 100.0, 30.0),
+                text="",
+                role=RegionRole.PARAGRAPH,
+                source=RegionSource.OCR,
+            )
+        ]
+
+
+class _StubOCR:
+    """Fill ``text`` with a fixed string so we can assert on output."""
+
+    def __init__(self, text: str = "stubbed") -> None:
+        self.text = text
+        self.calls = 0
+
+    def transcribe(self, region: Region, page_image: object) -> Region:
+        self.calls += 1
+        return region.with_text(self.text)
+
+
+class _FailingOCR:
+    """Raises on the configured ``fail_on_page`` (1-based)."""
+
+    def __init__(self, *, fail_on_page: int) -> None:
+        self.fail_on_page = fail_on_page
+
+    def transcribe(self, region: Region, page_image: object) -> Region:
+        if region.page_index + 1 == self.fail_on_page:
+            raise OCRTranscriptionError(f"stub failure on page {self.fail_on_page}")
+        return region.with_text("ok")
+
+
+def _accept_validator(page: object, config: ValidatorConfig) -> ValidationResult:
+    """Validator that always accepts → keeps the native branch."""
+    return ValidationResult(accept=True, signals={}, reasons=())
+
+
+def _reject_validator(page: object, config: ValidatorConfig) -> ValidationResult:
+    """Validator that always rejects → forces the ML branch."""
+    return ValidationResult(accept=False, signals={}, reasons=("forced_ml",))
+
+
+# ---------------------------------------------------------------------------
+# Native branch
+# ---------------------------------------------------------------------------
+
+
+def test_native_branch_no_ml_calls() -> None:
+    """Spec criterion: clean digital Arabic PDF takes native path,
+    no model load. Verified by the stubs being uncalled."""
+    layout = _StubLayoutDetector()
+    ocr = _StubOCR()
+    result = transcribe(
+        CLEAN,
+        layout_detector=layout,
+        ocr_transcriber=ocr,
+        validator=_accept_validator,
+    )
+    assert layout.calls == 0
+    assert ocr.calls == 0
+    assert result.n_pages >= 1
+    assert all(p.branch == "native" for p in result.pages)
+    assert result.failed_pages == 0
+
+
+def test_native_branch_omits_ml_adapters_entirely() -> None:
+    """No ML adapters needed when validator accepts every page."""
+    result = transcribe(CLEAN, validator=_accept_validator)
+    assert result.n_pages >= 1
+    assert all(p.branch == "native" for p in result.pages)
+
+
+# ---------------------------------------------------------------------------
+# ML branch
+# ---------------------------------------------------------------------------
+
+
+def test_ml_branch_runs_when_validator_rejects() -> None:
+    layout = _StubLayoutDetector()
+    ocr = _StubOCR(text="ml-result")
+    result = transcribe(
+        CLEAN,
+        layout_detector=layout,
+        ocr_transcriber=ocr,
+        validator=_reject_validator,
+    )
+    assert layout.calls >= 1
+    assert ocr.calls >= 1
+    assert all(p.branch == "ml" for p in result.pages)
+    assert any("ml-result" in r.text for r in result.regions)
+
+
+def test_ml_branch_without_adapters_synthesises_failure() -> None:
+    """When validator rejects but no adapters wired, default mode
+    synthesises a failure-placeholder region per page."""
+    result = transcribe(CLEAN, validator=_reject_validator)
+    assert all(p.branch == "failed" for p in result.pages)
+    assert all(p.regions[0].role is RegionRole.FAILURE_PLACEHOLDER for p in result.pages)
+
+
+# ---------------------------------------------------------------------------
+# Strict / best-effort
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_aborts_on_first_failure() -> None:
+    layout = _StubLayoutDetector()
+    ocr = _FailingOCR(fail_on_page=1)
+    with pytest.raises(OCRTranscriptionError):
+        transcribe(
+            CLEAN,
+            layout_detector=layout,
+            ocr_transcriber=ocr,
+            validator=_reject_validator,
+            strict=True,
+        )
+
+
+def test_best_effort_inserts_failure_placeholder() -> None:
+    layout = _StubLayoutDetector()
+    ocr = _FailingOCR(fail_on_page=1)
+    result = transcribe(
+        CLEAN,
+        layout_detector=layout,
+        ocr_transcriber=ocr,
+        validator=_reject_validator,
+        strict=False,
+    )
+    failed = [p for p in result.pages if p.branch == "failed"]
+    assert len(failed) >= 1
+    assert all(p.regions[0].role is RegionRole.FAILURE_PLACEHOLDER for p in failed)
+    assert all(p.regions[0].failure_reason == "OCRTranscriptionError" for p in failed)
+
+
+def test_all_failed_property_set_when_every_page_fails() -> None:
+    result = transcribe(CLEAN, validator=_reject_validator)
+    assert result.all_failed is True
+
+
+# ---------------------------------------------------------------------------
+# Page filter
+# ---------------------------------------------------------------------------
+
+
+def test_pages_filter_skips_unselected() -> None:
+    layout = _StubLayoutDetector()
+    ocr = _StubOCR()
+    result = transcribe(
+        CLEAN,
+        layout_detector=layout,
+        ocr_transcriber=ocr,
+        validator=_accept_validator,
+        pages=(0,),
+    )
+    assert result.n_pages == 1
+    assert result.pages[0].page_index == 0
+
+
+def test_pages_filter_does_not_invoke_validator_for_skipped_pages() -> None:
+    """Codex feedback: pages filter must short-circuit before
+    per-page work. The validator is the cheapest observable hook,
+    so we assert it's only called for selected pages."""
+    seen: list[int] = []
+
+    def _spy_validator(page: object, config: ValidatorConfig) -> ValidationResult:
+        # ``page`` is a NativePage; record its index.
+        seen.append(getattr(page, "page_index", -1))
+        return ValidationResult(accept=True, signals={}, reasons=())
+
+    transcribe(CLEAN, validator=_spy_validator, pages=(0,))
+    assert seen == [0], f"validator was invoked for unselected pages: {seen}"
+
+
+# ---------------------------------------------------------------------------
+# max_workers
+# ---------------------------------------------------------------------------
+
+
+def test_max_workers_accepted_in_signature() -> None:
+    """Codex feedback: ``--max-workers`` flows through to transcribe()."""
+    result = transcribe(CLEAN, validator=_accept_validator, max_workers=4)
+    assert result.n_pages >= 1
+
+
+def test_max_workers_invalid_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="max_workers must be >= 1"):
+        transcribe(CLEAN, validator=_accept_validator, max_workers=0)
+
+
+# ---------------------------------------------------------------------------
+# CUDA OOM detection (covers RuntimeError-shaped torch.cuda.OutOfMemoryError)
+# ---------------------------------------------------------------------------
+
+
+class _CudaOOMOCR:
+    """Stub that raises a synthetic ``torch.cuda.OutOfMemoryError``."""
+
+    def transcribe(self, region: Region, page_image: object) -> Region:
+        # Build a class whose ``__module__`` and ``__name__`` match
+        # what ``_is_cuda_oom`` checks for, without needing torch
+        # installed.
+        class _SyntheticCudaOOM(RuntimeError):
+            pass
+
+        _SyntheticCudaOOM.__module__ = "torch.cuda"
+        _SyntheticCudaOOM.__name__ = "OutOfMemoryError"
+        raise _SyntheticCudaOOM("CUDA out of memory")
+
+
+def test_cuda_oom_strict_raises_typed_oom() -> None:
+    from arabic_pdf_transcribe.errors import OutOfMemoryDuringInference
+
+    layout = _StubLayoutDetector()
+    with pytest.raises(OutOfMemoryDuringInference, match="CUDA OOM"):
+        transcribe(
+            CLEAN,
+            layout_detector=layout,
+            ocr_transcriber=_CudaOOMOCR(),
+            validator=_reject_validator,
+            strict=True,
+        )
+
+
+def test_cuda_oom_best_effort_synthesises_failure() -> None:
+    layout = _StubLayoutDetector()
+    result = transcribe(
+        CLEAN,
+        layout_detector=layout,
+        ocr_transcriber=_CudaOOMOCR(),
+        validator=_reject_validator,
+    )
+    assert all(p.branch == "failed" for p in result.pages)
+    assert all(p.failure_reason == "cuda_out_of_memory" for p in result.pages)
+
+
+# ---------------------------------------------------------------------------
+# Encrypted / corrupted PDFs surface from the loader
+# ---------------------------------------------------------------------------
+
+
+def test_corrupted_pdf_propagates(tmp_path: Path) -> None:
+    """Spec scenario 13: corrupted PDF → CorruptedPDFError (CLI maps to 4)."""
+    bogus = tmp_path / "bogus.pdf"
+    bogus.write_bytes(b"not a pdf")
+    from arabic_pdf_transcribe.errors import CorruptedPDFError
+
+    with pytest.raises(CorruptedPDFError):
+        transcribe(bogus, validator=_accept_validator)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_transcribe_byte_identical_regions() -> None:
+    """Native-path reproducibility (spec)."""
+    a = transcribe(CLEAN, validator=_accept_validator)
+    b = transcribe(CLEAN, validator=_accept_validator)
+    assert _serialise(a) == _serialise(b)
+
+
+def _serialise(result: TranscribeResult) -> str:
+    return "\n".join(r.to_json() for r in result.regions)
+
+
+# ---------------------------------------------------------------------------
+# Progress callback
+# ---------------------------------------------------------------------------
+
+
+def test_progress_callback_receives_start_and_complete_events() -> None:
+    events: list[tuple[int, int, str]] = []
+
+    def cb(page_index: int, total: int, event: str) -> None:
+        events.append((page_index, total, event))
+
+    transcribe(CLEAN, validator=_accept_validator, progress=cb)
+    assert any(e[2] == "start" for e in events)
+    assert any(e[2].startswith("complete:") for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Temp-dir cleanup (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_temp_dir_cleaned_up_on_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``tempfile.TemporaryDirectory`` removes the dir on context exit."""
+    seen: list[str] = []
+
+    import tempfile
+
+    real_cls = tempfile.TemporaryDirectory
+
+    class _Trackable(real_cls):  # type: ignore[misc]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            seen.append(self.name)
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", _Trackable)
+    transcribe(CLEAN, validator=_accept_validator)
+    gc.collect()
+    assert seen, "TemporaryDirectory should have been instantiated"
+    for d in seen:
+        assert not Path(d).exists(), f"temp dir leaked: {d}"
+
+
+def test_temp_dir_cleaned_up_on_strict_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    import tempfile
+
+    real_cls = tempfile.TemporaryDirectory
+
+    class _Trackable(real_cls):  # type: ignore[misc]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            seen.append(self.name)
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", _Trackable)
+    layout = _StubLayoutDetector()
+    ocr = _FailingOCR(fail_on_page=1)
+    with pytest.raises(OCRTranscriptionError):
+        transcribe(
+            CLEAN,
+            layout_detector=layout,
+            ocr_transcriber=ocr,
+            validator=_reject_validator,
+            strict=True,
+        )
+    for d in seen:
+        assert not Path(d).exists(), f"temp dir leaked on strict failure: {d}"

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -40,18 +40,17 @@ def test_errors_module_has_base_and_phase4_5_exceptions() -> None:
     assert issubclass(errors.OCRTranscriptionError, errors.ArabicPdfTranscribeError)
 
 
-def test_cli_stub_raises_not_implemented() -> None:
-    """The CLI entry point exists so ``pip install`` registers it cleanly.
-
-    Calling it before phase 8 must fail loudly rather than silently produce
-    empty or wrong output. Phase 8 will replace the body.
-    """
+def test_cli_main_is_callable() -> None:
+    """Phase 8 replaced the phase-1 placeholder. The entry point now
+    drives the full pipeline; ``--help`` short-circuits with exit 0
+    via argparse's ``SystemExit``."""
     import pytest
 
     from arabic_pdf_transcribe import cli
 
-    with pytest.raises(NotImplementedError, match="phase 8"):
-        cli.main([])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+    assert exc_info.value.code == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 8 wires every prior phase into one CLI surface and ships the orchestrator that drives native → validate → layout → OCR → reorder → roles → emit per page. The CLI implements the full set of flags from the spec's "Resolved Decisions" section and maps all five typed errors to the spec-defined exit codes (0/2/3/4/5).

### CLI

```
arabic-pdf-transcribe FILE [-o PATH] [--format md|docx] [--pages RANGES]
    [--strict] [--quiet] [--json-logs] [--config PATH] [--debug-json PATH]
    [--max-workers N] [--dpi N]
```

| Exit | Cause |
|---|---|
| 0 | success (incl. best-effort with some failed pages) |
| 2 | `--strict` abort, or every page failed |
| 3 | encrypted PDF |
| 4 | corrupted PDF, or `--format` ↔ output extension disagreement |
| 5 | ML model missing (cache miss / offline) |

### Pipeline

`transcribe(pdf_path, *, layout_detector, ocr_transcriber, validator, ...) -> TranscribeResult`. All four pluggable hooks accept any object conforming to the relevant Protocol; defaults are wired when omitted. Pages outside `--pages` short-circuit before any per-page work. CUDA OOM is detected by class metadata (`__module__ == "torch"`, `__name__ == "OutOfMemoryError"`) so the orchestrator stays free of `torch` imports. Failure-region synthesis hands `FAILURE_PLACEHOLDER` regions to the phase-7 emitters so failed pages still produce output.

### Logging

`ProgressLogger` with `TEXT` / `QUIET` / `JSON` modes. No timestamps in JSON mode → byte-stable stderr across runs.

### Iter-1 consultation

- **codex** — `REQUEST_CHANGES` (HIGH): 4 concrete issues (pages filter materialised whole PDF, `--max-workers` discarded, `--format docx` without `-o` raised in writer, GPU OOM not caught). All fixed.
- **claude** — `REQUEST_CHANGES` (HIGH): overlapping issues + missing exit-5 integration test. All fixed.
- **gemini** — `SKIPPED`: API quota exhausted (10 retries, same as phases 4–7).

Rebuttals: `codev/projects/1-arabic-pdf-transcriber-extract/1-phase_8_cli_and_pipeline_orchestrator-iter1-rebuttals.md` (in worktree, not on PR branch — same as prior phases).

## Test plan

- [x] `make test` → 363 passed, 2 deselected (was 356; +7 phase-8 regression tests for the codex/claude issues)
- [x] `make lint` → clean
- [x] `make audit` (license_audit) → OK
- [x] CLI smoke on `tests/fixtures/pdfs/digital-clean/lorem-ar-real.pdf` produces non-empty Arabic Markdown to stdout
- [x] `--format docx -o out.docx` writes a valid Word file (PK\x03\x04 magic asserted)
- [x] All 5 exit-code paths covered (0/2/3/4/5)
- [x] Temp-dir cleanup verified on success and strict-abort paths
- [x] CUDA OOM strict and best-effort behaviours verified via synthetic class

🤖 Generated with [Claude Code](https://claude.com/claude-code)