### PR TITLE
Fix #22: cast fp32 image inputs to model dtype in HF adapters

### DIFF
--- a/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
+++ b/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: fp16-bf16-path-broken-image-in
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-03T01:08:06.865Z'
-updated_at: '2026-05-03T01:08:06.866Z'
+updated_at: '2026-05-03T01:11:34.233Z'

--- a/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
+++ b/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: fp16-bf16-path-broken-image-in
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-03T01:08:06.865Z'
-updated_at: '2026-05-03T01:11:34.233Z'
+updated_at: '2026-05-03T01:20:11.377Z'

--- a/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
+++ b/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-22
+title: fp16-bf16-path-broken-image-in
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-03T01:08:06.865Z'
+updated_at: '2026-05-03T01:08:06.866Z'

--- a/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
+++ b/codev/projects/bugfix-22-fp16-bf16-path-broken-image-in/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-22
 title: fp16-bf16-path-broken-image-in
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-03T01:08:06.865Z'
-updated_at: '2026-05-03T01:20:11.377Z'
+updated_at: '2026-05-03T01:26:37.161Z'

--- a/src/arabic_pdf_transcribe/_device.py
+++ b/src/arabic_pdf_transcribe/_device.py
@@ -58,26 +58,79 @@ def resolve_device(requested: str | None) -> str:
     return "cpu"
 
 
-def move_inputs_to_device(inputs: Any, device: str) -> Any:
-    """Move processor outputs to ``device`` for both adapters.
+def move_inputs_to_device(inputs: Any, device: str, dtype: Any = None) -> Any:
+    """Move processor outputs to ``device`` (and optionally cast to ``dtype``).
 
     Real ``BatchEncoding`` objects expose ``.to(device)`` directly;
     test stubs return plain dicts (no ``.to``). Fall back to a
     per-tensor move so stubs and real outputs both work.
+
+    Issue #22 RC#1: image processors return ``pixel_values`` as fp32
+    regardless of the model's loaded dtype. Running fp32 inputs through
+    fp16/bf16 weights raises ``RuntimeError: Input type (float) and bias
+    type (c10::Half) should be the same``. When ``dtype`` is non-None
+    and differs from float32, cast the floating-point tensors (only —
+    int64 ``input_ids`` / ``attention_mask`` must stay int64) to match.
     """
-    move = getattr(inputs, "to", None)
-    if callable(move):
-        try:
-            return move(device)
-        except (TypeError, AttributeError, RuntimeError):
-            pass
     try:
         import torch
     except ImportError:  # pragma: no cover
         return inputs
+
+    needs_cast = dtype is not None and dtype is not torch.float32
+
+    move = getattr(inputs, "to", None)
+    if callable(move):
+        try:
+            moved = move(device)
+        except (TypeError, AttributeError, RuntimeError):
+            moved = None
+        if moved is not None:
+            if not needs_cast:
+                return moved
+            mapping = _as_tensor_mapping(moved)
+            if mapping is not None:
+                _cast_floating_inplace(mapping, dtype, torch)
+                return moved
+            # mapping inaccessible — fall through to dict path.
+
     if not isinstance(inputs, dict):
         return inputs
-    return {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
+    moved_dict = {
+        k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()
+    }
+    if needs_cast:
+        _cast_floating_inplace(moved_dict, dtype, torch)
+    return moved_dict
+
+
+def _as_tensor_mapping(inputs: Any) -> Any:
+    """Return ``inputs`` if it behaves like a mutable ``str -> Tensor`` mapping.
+
+    ``BatchEncoding`` / ``BatchFeature`` quack like dicts (``__iter__``
+    yields keys, ``__getitem__`` / ``__setitem__`` work). Plain dicts
+    qualify too. Returns ``None`` for opaque containers.
+    """
+    if isinstance(inputs, dict):
+        return inputs
+    has_get = callable(getattr(inputs, "__getitem__", None))
+    has_set = callable(getattr(inputs, "__setitem__", None))
+    has_iter = callable(getattr(inputs, "__iter__", None))
+    if has_get and has_set and has_iter:
+        return inputs
+    return None
+
+
+def _cast_floating_inplace(mapping: Any, dtype: Any, torch: Any) -> None:
+    """Cast every floating-point tensor in ``mapping`` to ``dtype``.
+
+    Skips integer tensors (token IDs, attention masks) — casting
+    ``input_ids`` to fp16 would silently corrupt vocabulary indexing.
+    """
+    for key in list(mapping):
+        value = mapping[key]
+        if isinstance(value, torch.Tensor) and torch.is_floating_point(value):
+            mapping[key] = value.to(dtype)
 
 
 def is_cuda_oom(exc: BaseException) -> bool:

--- a/src/arabic_pdf_transcribe/layout/hf_detector.py
+++ b/src/arabic_pdf_transcribe/layout/hf_detector.py
@@ -142,6 +142,10 @@ class HFDiTLayoutDetector:
         # adapter's lifetime so a CUDA OOM can downgrade us to CPU
         # for the rest of the run (issue #18 RC#1).
         self._device: str | None = None
+        # Issue #22 RC#1: image processors return fp32 ``pixel_values``
+        # regardless of how the model was loaded; we must cast inputs to
+        # the model dtype before forward when running fp16/bf16.
+        self._dtype: Any = None
 
     def warm_up(self) -> None:
         """Force model + processor load now (otherwise lazy)."""
@@ -167,6 +171,7 @@ class HFDiTLayoutDetector:
         # to pick bf16/fp16 (CUDA) or stay fp32 (CPU). Issue #20 RC#1.
         self._device = resolve_device(self.config.device)
         torch_dtype = resolve_dtype(self.config.dtype, self._device)
+        self._dtype = torch_dtype
         load_kwargs: dict[str, Any] = {"revision": self.config.revision}
         if torch_dtype is not None:
             load_kwargs["torch_dtype"] = torch_dtype
@@ -213,7 +218,7 @@ class HFDiTLayoutDetector:
             with contextlib.suppress(Exception):
                 self._model.to("cuda")
         inputs = self._processor(images=page_image, return_tensors="pt")
-        inputs = move_inputs_to_device(inputs, self._device or "cpu")
+        inputs = move_inputs_to_device(inputs, self._device or "cpu", dtype=self._dtype)
         try:
             with torch.no_grad():
                 outputs = self._model(**inputs)
@@ -227,7 +232,7 @@ class HFDiTLayoutDetector:
                 torch.cuda.empty_cache()
             self._model.to("cpu")
             self._device = "cpu"
-            inputs = move_inputs_to_device(inputs, "cpu")
+            inputs = move_inputs_to_device(inputs, "cpu", dtype=self._dtype)
             with torch.no_grad():
                 outputs = self._model(**inputs)
         logits = outputs.logits  # (1, num_labels, h, w)

--- a/src/arabic_pdf_transcribe/ocr/hf_ocr.py
+++ b/src/arabic_pdf_transcribe/ocr/hf_ocr.py
@@ -159,6 +159,10 @@ class HFGotOCRTranscriber:
         self._model: Any = None
         self._processor: Any = None
         self._device: str | None = None
+        # Issue #22 RC#1: cast fp32 image inputs to model dtype before
+        # forward when running fp16/bf16, otherwise the forward raises
+        # "Input type (float) and bias type (c10::Half) should be the same".
+        self._dtype: Any = None
         # Issue #20 RC#3: a CUDA OOM gets one in-place retry on GPU
         # (after empty_cache) before we permanently fall back to CPU.
         # The flag stays set across regions so a subsequent OOM falls
@@ -189,6 +193,7 @@ class HFGotOCRTranscriber:
         # bf16 / fp16 only when actually heading to CUDA.
         self._device = resolve_device(self.config.device)
         torch_dtype = resolve_dtype(self.config.dtype, self._device)
+        self._dtype = torch_dtype
         load_kwargs: dict[str, Any] = {"revision": self.config.revision}
         if torch_dtype is not None:
             load_kwargs["torch_dtype"] = torch_dtype
@@ -286,7 +291,7 @@ class HFGotOCRTranscriber:
                 images=image,
                 return_tensors="pt",
             )
-            inputs = move_inputs_to_device(inputs, self._device or "cpu")
+            inputs = move_inputs_to_device(inputs, self._device or "cpu", dtype=self._dtype)
             outputs = self._run_generate(inputs, torch)
         except OCRTranscriptionError:
             raise
@@ -345,7 +350,7 @@ class HFGotOCRTranscriber:
                 torch.cuda.empty_cache()
             self._model.to("cpu")
             self._device = "cpu"
-            cpu_inputs = move_inputs_to_device(inputs, "cpu")
+            cpu_inputs = move_inputs_to_device(inputs, "cpu", dtype=self._dtype)
             with torch.no_grad():
                 return self._model.generate(**cpu_inputs, **kwargs)
 

--- a/tests/test_issue_22_regression.py
+++ b/tests/test_issue_22_regression.py
@@ -1,0 +1,273 @@
+"""Regression tests for issue #22 — fp16/bf16 image inputs not cast to model dtype.
+
+# Bug recap
+
+v0.1.5 fixed RC#1 of issue #20 by passing ``torch_dtype=fp16`` to
+``from_pretrained`` on Turing CUDA (compute capability 7.5). But the HF
+image processor still returns ``pixel_values`` as **fp32** regardless of
+the model's loaded dtype. The downstream forward then runs fp32 inputs
+through fp16 weights:
+
+    RuntimeError: Input type (float) and bias type (c10::Half) should be the same
+
+The shared helper ``move_inputs_to_device`` was device-only — it never
+inspected or changed dtype. The fix extends it to optionally cast every
+floating-point tensor (``pixel_values`` and friends) to the model dtype
+while leaving integer tensors (``input_ids``, ``attention_mask``) alone.
+
+# What the v0.1.5 suite missed
+
+``test_issue_20_regression.py`` mocked ``from_pretrained`` and
+``generate`` with stubs that ignored tensor dtypes. ``torch_dtype=`` was
+verified at the call site but no test ever ran a real fp16 weight
+through a real fp32 input. These tests close that integration gap with
+a real ``torch.nn.Linear(dtype=fp16)`` standing in for the conv layer
+that originally raised.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from arabic_pdf_transcribe._device import move_inputs_to_device
+
+# All tests in this module need a real ``torch`` to exercise the
+# dtype-mismatch boundary; if torch isn't installed (no [ml] extra),
+# skip cleanly rather than failing.
+torch = pytest.importorskip("torch")
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the test environment can actually surface the dtype-mismatch error
+# ---------------------------------------------------------------------------
+
+
+def test_environment_surfaces_fp16_weight_fp32_input_mismatch() -> None:
+    """Pre-condition for the rest of the file: a real fp16 ``Linear`` fed a
+    fp32 tensor must raise the exact error the issue reports. Without this
+    check, a passing test below could mean the bug, the test, or torch
+    silently up-promoting — we want certainty it's the fix."""
+    layer = torch.nn.Linear(8, 4, dtype=torch.float16)
+    fp32_input = torch.zeros((1, 8), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match=r"(?i)input type|bias type|same"):
+        layer(fp32_input)
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_move_inputs_casts_floating_point_dict_inputs_to_fp16() -> None:
+    """Plain-dict path (test stubs return dicts): floating-point tensors
+    cast to ``dtype``, int tensors stay int."""
+    inputs = {
+        "pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32),
+        "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.int64),
+        "attention_mask": torch.tensor([[1, 1, 1]], dtype=torch.int64),
+    }
+    moved = move_inputs_to_device(inputs, "cpu", dtype=torch.float16)
+    assert moved["pixel_values"].dtype is torch.float16
+    assert moved["input_ids"].dtype is torch.int64
+    assert moved["attention_mask"].dtype is torch.int64
+
+
+def test_move_inputs_casts_bf16() -> None:
+    inputs = {"pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32)}
+    moved = move_inputs_to_device(inputs, "cpu", dtype=torch.bfloat16)
+    assert moved["pixel_values"].dtype is torch.bfloat16
+
+
+def test_move_inputs_dtype_none_keeps_fp32() -> None:
+    """Backwards-compatible default: no ``dtype`` arg means no cast."""
+    inputs = {"pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32)}
+    moved = move_inputs_to_device(inputs, "cpu")
+    assert moved["pixel_values"].dtype is torch.float32
+
+
+def test_move_inputs_dtype_fp32_skips_cast_for_perf() -> None:
+    """When dtype is explicitly fp32 (CPU ``auto`` resolution) we
+    don't pay an unnecessary ``.to(float32)`` round-trip."""
+    pv = torch.zeros((1, 3, 4, 4), dtype=torch.float32)
+    inputs = {"pixel_values": pv}
+    moved = move_inputs_to_device(inputs, "cpu", dtype=torch.float32)
+    assert moved["pixel_values"].dtype is torch.float32
+
+
+def test_move_inputs_handles_batch_encoding_like_object() -> None:
+    """``BatchEncoding`` / ``BatchFeature`` have ``.to(device)`` plus
+    dict-style ``__getitem__`` / ``__setitem__``. Cast must work via
+    the in-place key path after ``.to`` returns the moved container."""
+
+    class _BatchEncodingLike:
+        def __init__(self, data: dict[str, Any]) -> None:
+            self._data = data
+
+        def to(self, device: str) -> _BatchEncodingLike:
+            self._data = {
+                k: (v.to(device) if isinstance(v, torch.Tensor) else v)
+                for k, v in self._data.items()
+            }
+            return self
+
+        def __getitem__(self, key: str) -> Any:
+            return self._data[key]
+
+        def __setitem__(self, key: str, value: Any) -> None:
+            self._data[key] = value
+
+        def __iter__(self):
+            return iter(self._data)
+
+    be = _BatchEncodingLike(
+        {
+            "pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32),
+            "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.int64),
+        }
+    )
+    moved = move_inputs_to_device(be, "cpu", dtype=torch.float16)
+    assert moved["pixel_values"].dtype is torch.float16
+    assert moved["input_ids"].dtype is torch.int64
+
+
+# ---------------------------------------------------------------------------
+# Layout adapter — real fp16 weights × fp32 processor outputs
+# ---------------------------------------------------------------------------
+
+
+class _Fp16LayoutModel:
+    """Stand-in for ``BeitForSemanticSegmentation`` whose first layer is
+    a real fp16 ``Linear``. Calling it with a fp32 ``pixel_values`` raises
+    the same RuntimeError the user hit — so a passing forward proves the
+    adapter cast inputs before calling us."""
+
+    def __init__(self, id2label: dict[int, str]) -> None:
+        self._layer = torch.nn.Linear(48, 2, dtype=torch.float16)
+        self.dtype = torch.float16
+
+        class _Cfg:
+            def __init__(self, labels: dict[int, str]) -> None:
+                self.id2label = labels
+
+        self.config = _Cfg(id2label)
+
+    def to(self, device: str) -> _Fp16LayoutModel:
+        return self
+
+    def __call__(self, **kwargs: Any) -> Any:
+        pixel_values = kwargs["pixel_values"]
+        # Flatten to a 48-feature vector then run the fp16 Linear; the
+        # operation raises if pixel_values is still fp32.
+        flat = pixel_values.reshape(pixel_values.shape[0], -1)
+        _ = self._layer(flat)
+        # Return a logits tensor that the adapter can softmax/argmax over.
+        h, w = 4, 4
+        logits = torch.zeros((1, 2, h, w), dtype=torch.float16)
+        logits[0, 1, :, :] = 5.0
+
+        class _Out:
+            pass
+
+        out = _Out()
+        out.logits = logits  # type: ignore[attr-defined]
+        return out
+
+
+class _Fp32PassthroughProcessor:
+    """The real DiT image processor returns fp32 ``pixel_values`` — we
+    mirror that here so the adapter must cast or the fp16 model raises."""
+
+    def __call__(self, *, images: object, return_tensors: str) -> dict[str, Any]:
+        # 4x4 spatial × 3 channels = 48 features for the fp16 Linear.
+        return {"pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32)}
+
+
+def test_layout_adapter_casts_pixel_values_to_model_dtype() -> None:
+    """Repro-equivalent: layout adapter loaded fp16, fp32 processor
+    output, GPU-ish forward — must NOT raise the dtype-mismatch error."""
+    from arabic_pdf_transcribe.layout.hf_detector import (
+        HFDiTLayoutDetector,
+        HFLayoutDetectorConfig,
+    )
+
+    detector = HFDiTLayoutDetector(HFLayoutDetectorConfig(device="cpu", dtype="float16"))
+    detector._processor = _Fp32PassthroughProcessor()
+    detector._model = _Fp16LayoutModel({0: "Background", 1: "Text"})
+    detector._id2label = {0: "Background", 1: "Text"}
+    detector._device = "cpu"
+    detector._dtype = torch.float16
+
+    from PIL import Image
+
+    page = Image.new("RGB", (16, 16), color=(255, 255, 255))
+    # Pre-fix this raised "Input type (float) and bias type (c10::Half)
+    # should be the same"; post-fix it returns regions cleanly.
+    regions = detector.detect(page, page_index=0)
+    assert isinstance(regions, list)
+
+
+# ---------------------------------------------------------------------------
+# OCR adapter — same input-prep boundary, exercised through ``_transcribe_image``
+# ---------------------------------------------------------------------------
+
+
+def test_ocr_adapter_casts_pixel_values_to_model_dtype() -> None:
+    """OCR adapter ``_transcribe_image`` is the bug-prone path; the
+    fp16 ``Linear`` inside ``_StubGenerateModel`` raises the exact issue-22
+    error if the adapter forgot to cast inputs to fp16.
+    """
+    from arabic_pdf_transcribe.ocr.hf_ocr import HFGotOCRTranscriber, OCRConfig
+
+    class _StubProcessor:
+        def __call__(self, *, images: object, return_tensors: str) -> dict[str, Any]:
+            return {
+                "pixel_values": torch.zeros((1, 3, 4, 4), dtype=torch.float32),
+                "input_ids": torch.tensor([[101, 102]], dtype=torch.int64),
+            }
+
+        def batch_decode(self, sequences: Any, **kwargs: Any) -> list[str]:
+            return [""]
+
+    class _StubGenerateModel:
+        def __init__(self) -> None:
+            self._layer = torch.nn.Linear(48, 4, dtype=torch.float16)
+            self.dtype = torch.float16
+
+        def to(self, device: str) -> _StubGenerateModel:
+            return self
+
+        def generate(self, **kwargs: Any) -> Any:
+            pixel_values = kwargs["pixel_values"]
+            assert pixel_values.dtype is torch.float16, (
+                "regression: pixel_values reached generate() as "
+                f"{pixel_values.dtype}, expected float16"
+            )
+            # Exercise the real fp16 ``Linear`` — this is what raises
+            # in the buggy code path.
+            _ = self._layer(pixel_values.reshape(pixel_values.shape[0], -1))
+            input_ids = kwargs.get("input_ids")
+            prompt_len = int(input_ids.shape[1]) if input_ids is not None else 0
+
+            class _Out:
+                sequences: Any = None
+                scores: tuple[Any, ...] = ()
+
+            out = _Out()
+            out.sequences = torch.zeros((1, prompt_len), dtype=torch.int64)
+            out.scores = ()
+            return out
+
+    transcriber = HFGotOCRTranscriber(OCRConfig(device="cpu", dtype="float16"))
+    transcriber._processor = _StubProcessor()
+    transcriber._model = _StubGenerateModel()
+    transcriber._device = "cpu"
+    transcriber._dtype = torch.float16
+
+    from PIL import Image
+
+    crop = Image.new("RGB", (16, 16), color=(255, 255, 255))
+    text, confidence = transcriber._transcribe_image(crop)
+    assert isinstance(text, str)
+    assert confidence is None  # no scores returned


### PR DESCRIPTION
## Summary

On non-Ampere CUDA (e.g. GTX 1660 Ti, capability 7.5) v0.1.5 fails on
every page with `RuntimeError: Input type (float) and bias type
(c10::Half) should be the same`. The layout/OCR adapters loaded weights
in fp16 (issue #20 RC#1) but the HF image processor returns
`pixel_values` as fp32. Cast floating-point inputs to the model dtype
before forward and the repro from the issue runs cleanly on a 6 GB GPU.

Fixes #22

## Root Cause

`move_inputs_to_device` (`src/arabic_pdf_transcribe/_device.py`) was
device-only — `tensor.to(device)` does **not** change dtype. Both HF
adapters resolved a fp16/bf16 model dtype, loaded the model in that
dtype, then ran the fp32 processor output through it. The v0.1.5 test
suite missed this because every test stub ignored tensor dtypes; the
`torch_dtype=` kwarg was verified at the call site, not at the
input-prep boundary.

## Fix

`move_inputs_to_device(inputs, device, dtype=None)` — the new optional
`dtype` argument casts every floating-point tensor (`pixel_values` and
friends) to the target dtype while leaving integer tensors
(`input_ids`, `attention_mask`) intact. Both HF adapters store the
resolved torch dtype in `_ensure_loaded` and pass it on every input
prep, including the CUDA-OOM → CPU fallback path.

Diff: 4 files, +349 / -13 (mostly the new regression test file). No
public API changes; CLI surface unchanged.

## Test Plan

- [x] Regression test added (`tests/test_issue_22_regression.py`, +8 tests):
  - Sanity: real fp16 `nn.Linear` × fp32 input raises the exact issue-22
    `RuntimeError` (proves the test environment surfaces the boundary).
  - Helper unit tests: dict path, `BatchEncoding`-like path, fp16/bf16
    casts, integer tensors preserved, `dtype=fp32`/`dtype=None`
    short-circuits.
  - End-to-end-ish: layout adapter `detect()` and OCR adapter
    `_transcribe_image()` route fp32 processor outputs through a real
    `torch.nn.Linear(dtype=fp16)` — the layer raises iff the adapter
    forgets to cast.
- [x] Build passes (`make lint` — ruff clean)
- [x] All tests pass (482 = 474 existing + 8 new)
- [x] No mypy regressions (only the pre-existing `transformers` import-untyped warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)