### PR TITLE
Fix #24: forward tokenizer + stop_strings to GOT-OCR-2.0 generate()

### DIFF
--- a/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
+++ b/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-24
 title: ocr-produces-garbage-tokens-go
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-03T02:15:36.178Z'
-updated_at: '2026-05-03T02:15:36.178Z'
+updated_at: '2026-05-03T02:19:44.956Z'

--- a/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
+++ b/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-24
 title: ocr-produces-garbage-tokens-go
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-03T02:15:36.178Z'
-updated_at: '2026-05-03T02:19:44.956Z'
+updated_at: '2026-05-03T02:23:55.478Z'

--- a/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
+++ b/codev/projects/bugfix-24-ocr-produces-garbage-tokens-go/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-24
+title: ocr-produces-garbage-tokens-go
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-03T02:15:36.178Z'
+updated_at: '2026-05-03T02:15:36.178Z'

--- a/src/arabic_pdf_transcribe/ocr/hf_ocr.py
+++ b/src/arabic_pdf_transcribe/ocr/hf_ocr.py
@@ -111,6 +111,12 @@ DEFAULT_NO_REPEAT_NGRAM_SIZE = 3
 DEFAULT_REPETITION_PENALTY = 1.05
 DEFAULT_DEVICE = "auto"
 DEFAULT_DTYPE = "auto"
+# Issue #24: GOT-OCR-2.0 uses a chat-template ending with this special
+# token; without forwarding it as ``stop_strings`` (and ``tokenizer=``
+# so generate can detect it in the decoded output) the model never
+# stops at the natural end of OCR text and emits sampled noise until
+# ``max_new_tokens`` runs out.
+OCR_STOP_STRING = "<|im_end|>"
 
 
 @dataclass(frozen=True)
@@ -355,8 +361,17 @@ class HFGotOCRTranscriber:
                 return self._model.generate(**cpu_inputs, **kwargs)
 
     def _generate_kwargs(self) -> dict[str, Any]:
-        """Decoding kwargs forwarded to ``model.generate`` (DRY across retries)."""
-        return {
+        """Decoding kwargs forwarded to ``model.generate`` (DRY across retries).
+
+        Issue #24: GOT-OCR-2.0's chat-template generation never emits
+        a built-in EOS at the natural end of OCR output; the upstream
+        recipe relies on ``stop_strings="<|im_end|>"`` (paired with
+        ``tokenizer=`` so generate can decode the running output to
+        match the stop string) to terminate cleanly. Without this
+        pair, generation runs to ``max_new_tokens`` and the trailing
+        tokens are sampled noise — math symbols, CJK, control bytes.
+        """
+        kwargs: dict[str, Any] = {
             "max_new_tokens": self.config.max_new_tokens,
             "num_beams": self.config.num_beams,
             "do_sample": self.config.do_sample,
@@ -366,6 +381,11 @@ class HFGotOCRTranscriber:
             "return_dict_in_generate": True,
             "output_scores": True,
         }
+        tokenizer = getattr(self._processor, "tokenizer", None)
+        if tokenizer is not None:
+            kwargs["tokenizer"] = tokenizer
+            kwargs["stop_strings"] = OCR_STOP_STRING
+        return kwargs
 
 
 def _confidence_from_scores(outputs: Any, gen_tokens: Any) -> float | None:
@@ -373,7 +393,10 @@ def _confidence_from_scores(outputs: Any, gen_tokens: Any) -> float | None:
 
     Returns ``None`` when the model did not expose per-token scores
     (e.g. wrapped models that override ``generate`` and drop
-    ``output_scores``).
+    ``output_scores``) or when the score tensors cannot be aligned
+    with ``gen_tokens`` (issue #24: ``stop_strings`` truncates the
+    output mid-step, which on some transformers versions misaligns
+    the scores tuple — degrade to ``None`` rather than raising).
     """
     try:
         import torch
@@ -382,18 +405,22 @@ def _confidence_from_scores(outputs: Any, gen_tokens: Any) -> float | None:
     scores = getattr(outputs, "scores", None)
     if scores is None or len(scores) == 0:
         return None
-    log_prob_sum = 0.0
-    counted = 0
-    # ``scores`` is a tuple of length-``num_new_tokens`` tensors,
-    # each shape ``(batch, vocab)``. ``gen_tokens`` is the chosen
-    # token ids, length ``num_new_tokens``.
-    for step_idx, step_scores in enumerate(scores):
-        if step_idx >= len(gen_tokens):
-            break
-        tok_id = int(gen_tokens[step_idx])
-        log_probs = torch.log_softmax(step_scores[0], dim=-1)
-        log_prob_sum += float(log_probs[tok_id])
-        counted += 1
+    try:
+        log_prob_sum = 0.0
+        counted = 0
+        # ``scores`` is a tuple of length-``num_new_tokens`` tensors,
+        # each shape ``(batch, vocab)``. ``gen_tokens`` is the chosen
+        # token ids, length ``num_new_tokens``.
+        for step_idx, step_scores in enumerate(scores):
+            if step_idx >= len(gen_tokens):
+                break
+            tok_id = int(gen_tokens[step_idx])
+            log_probs = torch.log_softmax(step_scores[0], dim=-1)
+            log_prob_sum += float(log_probs[tok_id])
+            counted += 1
+    except Exception as exc:
+        LOGGER.debug("OCR: confidence aggregation skipped (%s)", exc)
+        return None
     if counted == 0:
         return None
     return math.exp(log_prob_sum / counted)

--- a/tests/test_issue_24_regression.py
+++ b/tests/test_issue_24_regression.py
@@ -1,0 +1,240 @@
+"""Regression tests for issue #24.
+
+Pre-fix symptom: the GOT-OCR-2.0 adapter called ``model.generate``
+without ``tokenizer=`` or ``stop_strings="<|im_end|>"``. The model's
+chat template never emits a built-in EOS at the natural end of OCR
+output, so generation ran to ``max_new_tokens`` and the trailing
+tokens were sampled noise — math symbols, CJK, control bytes,
+``\\n11\\n11`` line-noise. The pipeline produced a 73 KB "successful"
+output that was almost entirely garbage.
+
+Fix: ``_generate_kwargs`` now forwards ``tokenizer=processor.tokenizer``
+and ``stop_strings=OCR_STOP_STRING`` so HF's generate loop terminates
+at the natural end of OCR output. These tests assert the kwargs are
+present (and have the expected values) on every code path that calls
+``model.generate`` — the simple path and the CUDA-OOM CPU-fallback
+path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+from arabic_pdf_transcribe.ocr.hf_ocr import (  # noqa: E402
+    OCR_STOP_STRING,
+    HFGotOCRTranscriber,
+    OCRConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeTokenizer:
+    """Stand-in for ``processor.tokenizer`` — identity is what we assert."""
+
+
+class _ProcessorWithTokenizer:
+    def __init__(self) -> None:
+        self.tokenizer = _FakeTokenizer()
+
+    def __call__(self, *, images: object, return_tensors: str) -> dict[str, Any]:
+        import torch
+
+        return {
+            "pixel_values": torch.zeros((1, 3, 16, 16)),
+            "input_ids": torch.zeros((1, 1), dtype=torch.long),
+        }
+
+    def batch_decode(self, sequences: object, *, skip_special_tokens: bool = True) -> list[str]:
+        return [""]
+
+
+class _CapturingModel:
+    """Records kwargs from each ``generate`` call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(self, **kwargs: Any) -> Any:
+        import torch
+
+        self.calls.append(dict(kwargs))
+
+        class _Out:
+            sequences = torch.zeros((1, 2), dtype=torch.long)
+            scores: tuple[Any, ...] = ()
+
+        return _Out()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_stop_string_constant_matches_got_ocr_chat_template() -> None:
+    """The chat template GOT-OCR-2.0 ships with terminates each turn
+    with ``<|im_end|>``. If this constant drifts the fix breaks
+    silently — generation runs to max_new_tokens again."""
+    assert OCR_STOP_STRING == "<|im_end|>"
+
+
+def test_generate_receives_tokenizer_and_stop_strings() -> None:
+    """Issue #24 RC: both kwargs must reach ``model.generate``."""
+    pytest.importorskip("torch")
+
+    processor = _ProcessorWithTokenizer()
+    model = _CapturingModel()
+
+    transcriber = HFGotOCRTranscriber()
+    transcriber._processor = processor
+    transcriber._model = model
+
+    image = Image.new("RGB", (40, 40), color=(255, 255, 255))
+    transcriber._transcribe_image(image)
+
+    assert len(model.calls) == 1
+    kwargs = model.calls[0]
+    assert "tokenizer" in kwargs, (
+        "regression: tokenizer= must be forwarded to generate so "
+        "stop_strings can be matched against decoded output"
+    )
+    assert kwargs["tokenizer"] is processor.tokenizer
+    assert kwargs.get("stop_strings") == OCR_STOP_STRING
+
+
+def test_generate_kwargs_preserves_existing_repetition_controls() -> None:
+    """The fix must not regress issue #20 RC#3 — repetition controls
+    still need to ride along on every generate call (defence in depth
+    for adversarial crops)."""
+    pytest.importorskip("torch")
+
+    processor = _ProcessorWithTokenizer()
+    model = _CapturingModel()
+
+    transcriber = HFGotOCRTranscriber(OCRConfig())
+    transcriber._processor = processor
+    transcriber._model = model
+
+    image = Image.new("RGB", (40, 40), color=(255, 255, 255))
+    transcriber._transcribe_image(image)
+
+    kwargs = model.calls[0]
+    assert kwargs["no_repeat_ngram_size"] == 3
+    assert kwargs["repetition_penalty"] == pytest.approx(1.05)
+    assert kwargs["max_new_tokens"] == 512
+    assert kwargs["return_dict_in_generate"] is True
+    assert kwargs["output_scores"] is True
+
+
+def test_oom_cpu_fallback_path_also_forwards_stop_strings() -> None:
+    """The CUDA-OOM → CPU-fallback retry must also use the corrected
+    kwargs; otherwise a fallback run silently degrades to garbage
+    output. Walks ``_run_generate`` directly with a model that OOMs
+    twice (initial + retry) to force the permanent CPU fallback."""
+    pytest.importorskip("torch")
+    import torch
+
+    processor = _ProcessorWithTokenizer()
+    captured: list[dict[str, Any]] = []
+    oom_count = {"n": 0}
+
+    class _OOMOnGPUModel:
+        def to(self, device: str) -> _OOMOnGPUModel:
+            return self
+
+        def generate(self, **kwargs: Any) -> Any:
+            captured.append(dict(kwargs))
+            if oom_count["n"] < 2:
+                oom_count["n"] += 1
+                raise RuntimeError("CUDA out of memory")
+
+            class _Out:
+                sequences = torch.zeros((1, 2), dtype=torch.long)
+                scores: tuple[Any, ...] = ()
+
+            return _Out()
+
+    transcriber = HFGotOCRTranscriber(OCRConfig(device="cuda"))
+    transcriber._processor = processor
+    transcriber._model = _OOMOnGPUModel()
+    transcriber._device = "cuda"
+
+    inputs = processor(images=Image.new("RGB", (16, 16)), return_tensors="pt")
+    transcriber._run_generate(inputs, torch)
+
+    # Three attempts: GPU, GPU retry, CPU fallback. All three must
+    # carry tokenizer + stop_strings.
+    assert len(captured) == 3
+    for call in captured:
+        assert call.get("stop_strings") == OCR_STOP_STRING
+        assert call.get("tokenizer") is processor.tokenizer
+
+
+def test_processor_without_tokenizer_skips_stop_strings() -> None:
+    """Defensive: stub processors used in unit tests across the suite
+    have no ``tokenizer`` attribute. The adapter must not raise on
+    them — instead, omit ``tokenizer=``/``stop_strings=`` so existing
+    tests keep working. Production HF AutoProcessor always exposes
+    ``tokenizer`` so the real fix still applies end-to-end."""
+    pytest.importorskip("torch")
+
+    class _NoTokProcessor:
+        def __call__(self, *, images: object, return_tensors: str) -> dict[str, Any]:
+            import torch
+
+            return {
+                "pixel_values": torch.zeros((1, 3, 16, 16)),
+                "input_ids": torch.zeros((1, 1), dtype=torch.long),
+            }
+
+        def batch_decode(self, *args: Any, **kwargs: Any) -> list[str]:
+            return [""]
+
+    model = _CapturingModel()
+    transcriber = HFGotOCRTranscriber()
+    transcriber._processor = _NoTokProcessor()
+    transcriber._model = model
+
+    image = Image.new("RGB", (40, 40), color=(255, 255, 255))
+    transcriber._transcribe_image(image)
+
+    kwargs = model.calls[0]
+    assert "tokenizer" not in kwargs
+    assert "stop_strings" not in kwargs
+
+
+def test_confidence_degrades_to_none_when_aggregation_raises() -> None:
+    """Issue #24 concern #3: ``stop_strings`` interacts with score
+    collection. If aggregating the per-token logits raises (e.g.
+    misaligned scores tuple), the adapter must return
+    ``confidence=None`` for that region rather than crashing."""
+    pytest.importorskip("torch")
+    import torch
+
+    processor = _ProcessorWithTokenizer()
+
+    class _BogusScoresModel:
+        def generate(self, **kwargs: Any) -> Any:
+            class _Out:
+                sequences = torch.zeros((1, 3), dtype=torch.long)
+                # Non-tensor scores entry → log_softmax raises RuntimeError.
+                scores = (object(),)
+
+            return _Out()
+
+    transcriber = HFGotOCRTranscriber()
+    transcriber._processor = processor
+    transcriber._model = _BogusScoresModel()
+
+    image = Image.new("RGB", (40, 40), color=(255, 255, 255))
+    text, confidence = transcriber._transcribe_image(image)
+    assert isinstance(text, str)
+    assert confidence is None


### PR DESCRIPTION
## Summary

Fixes #24.

GOT-OCR-2.0's chat template never emits a built-in EOS at the natural end of OCR output; the upstream HF recipe relies on `stop_strings="< |im_end|>"` (paired with `tokenizer=processor.tokenizer` so generate can decode the running output to match the stop) to terminate cleanly. The adapter was omitting both kwargs, so generation ran to `max_new_tokens` and the trailing tokens were sampled noise — math symbols, CJK, control bytes, `\nnnn\n11` line-noise. A user run produced a 73 KB "successful" output that was almost entirely garbage.

## Changes

- **`src/arabic_pdf_transcribe/ocr/hf_ocr.py`**:
  - New module-level `OCR_STOP_STRING = "<|im_end|>"` constant (one place to update if upstream changes the chat template).
  - `_generate_kwargs` now forwards `tokenizer=` and `stop_strings=` whenever the processor exposes a `tokenizer` attribute. The real HF `AutoProcessor` always does; the conditional keeps existing stub-injected unit tests across the suite working without invasive churn.
  - `_confidence_from_scores` wraps the per-token aggregation in a broad `try/except`. Concern #3 in the issue: `stop_strings` decodes the running output to detect termination, which on some `transformers` versions misaligns the scores tuple. Per the issue, we degrade to `confidence=None` rather than crashing the region.

- **`tests/test_issue_24_regression.py`** (new — 6 tests):
  - `test_stop_string_constant_matches_got_ocr_chat_template` — pins the stop string so silent drift is caught.
  - `test_generate_receives_tokenizer_and_stop_strings` — RC assertion that both kwargs reach `model.generate`.
  - `test_generate_kwargs_preserves_existing_repetition_controls` — issue #20 RC#3 controls still ride along.
  - `test_oom_cpu_fallback_path_also_forwards_stop_strings` — the GPU OOM → GPU retry → permanent CPU fallback path also carries the corrected kwargs (a fallback run silently degrading to garbage was the worst plausible regression).
  - `test_processor_without_tokenizer_skips_stop_strings` — documents the conditional, keeps the rest of the suite green.
  - `test_confidence_degrades_to_none_when_aggregation_raises` — concern #3 graceful degrade.

## Acceptance

1. Generated tokens now stop at the natural end of OCR output (acceptance #2). Verified by stop-string assertion in regression test; end-to-end verification on the repro PDF will be done by the architect after merge.
2. Regression test asserts `tokenizer=` and `stop_strings=` are forwarded (acceptance #3) on both the simple and OOM-fallback paths.
3. Existing 482 tests + 6 new = 488 tests green (acceptance #4).
4. The `@pytest.mark.slow` gap noted in "Why testing missed this" remains for a follow-up — wiring an opt-in real-model end-to-end test is out of scope for this BUGFIX (the kwarg-shape regression is what reliably catches the bug class; a real-model test catches the next one but adds a weights-download dependency to CI).

## Test plan

- [x] `make test` (488 passed)
- [x] `ruff check src/ tests/` clean
- [ ] Architect verifies on real GTX 1660 Ti with the repro command from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)